### PR TITLE
use pkg.module key to expose es6-module type file, and fixed paths

### DIFF
--- a/packages/context-fetch/package.json
+++ b/packages/context-fetch/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.6",
   "private": false,
   "main": "dist/index.js",
-  "jsnext:main": "src/index.js",
+  "module": "src/index.ts",
   "description": "Inject authentification behavior to fetch using react High Order Component",
   "repository": {
     "type": "git",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.6",
   "private": false,
   "main": "dist/index.js",
-  "jsnext:main": "src/index.js",
+  "module": "src/index.ts",
   "description": "OpenID Connect & OAuth authentication using react context api as state management",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "description": "A core package for Axa React Oidc packages",
   "homepage": "https://github.com/AxaGuilDEv/react-oidc#readme",
   "main": "dist/index.js",
-  "jsnext:main": "src/index.js",
+  "module": "src/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/AxaGuilDEv/react-oidc.git"

--- a/packages/fetch-core/package.json
+++ b/packages/fetch-core/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.6",
   "private": false,
   "main": "dist/index.js",
-  "jsnext:main": "src/index.js",
+  "module": "src/index.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/AxaGuilDEv/react-oidc.git"

--- a/packages/fetch-observable/package.json
+++ b/packages/fetch-observable/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.6",
   "private": false,
   "main": "dist/index.js",
-  "jsnext:main": "src/index.js",
+  "module": "src/index.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/AxaGuilDEv/react-oidc.git"

--- a/packages/redux-fetch/package.json
+++ b/packages/redux-fetch/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.6",
   "private": false,
   "main": "dist/index.js",
-  "jsnext:main": "src/index.js",
+  "module": "src/index.ts",
   "description": "Inject authentification behavior to fetch using react High Order Component",
   "repository": {
     "type": "git",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.6",
   "private": false,
   "main": "dist/index.js",
-  "jsnext:main": "src/index.js",
+  "module": "src/index.ts",
   "description": "OpenID Connect & OAuth authentication using react and redux as state management",
   "repository": {
     "type": "git",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.6",
   "private": false,
   "main": "dist/index.js",
-  "jsnext:main": "src/index.js",
+  "module": "src/index.js",
   "description": "OpenID Connect & OAuth authentication using oidc-client wrapped in order to simplify how to use it",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since pkg.module is becoming the defacto standard for serving ES2015 files, I replaced `jsnext:main` with it.
I also fixed the paths where files where index.ts but the package.json said index.js.

This will allow tree-shaking to actually work, and allow the use of bundlers like **vite** who only accept packages with valid module configuration.

References : https://medium.com/webpack/webpack-and-rollup-the-same-but-different-a41ad427058c
https://github.com/nodejs/node-eps/blob/4217dca299d89c8c18ac44c878b5fe9581974ef3/002-es6-modules.md#51-determining-if-source-is-an-es-module
