### PR TITLE
fix: database for `default` configuration not initializing properly

### DIFF
--- a/packages/react/service_worker/OidcServiceWorker.ts
+++ b/packages/react/service_worker/OidcServiceWorker.ts
@@ -37,18 +37,7 @@ const handleActivate = (event: ExtendableEvent) => {
 };
 
 let currentLoginCallbackConfigurationName: string | null = null;
-const database: Database = {
-  default: {
-    configurationName: 'default',
-    tokens: null,
-    status: null,
-    state: null,
-    codeVerifier: null,
-    nonce: null,
-    oidcServerConfiguration: null,
-    hideAccessToken: true,
-  },
-};
+const database: Database = {};
 
 const getCurrentDatabasesTokenEndpoint = (database: Database, url: string) => {
   const databases: OidcConfig[] = [];


### PR DESCRIPTION
Databases for all configuration names are created here: https://github.com/AxaFrance/react-oidc/blob/3e535c94dc57d59956498bfa0ca9536106039bda/packages/react/service_worker/OidcServiceWorker.ts#L288

Before a database is created, there's a check whether it already exists: https://github.com/AxaFrance/react-oidc/blob/3e535c94dc57d59956498bfa0ca9536106039bda/packages/react/service_worker/OidcServiceWorker.ts#L282

But the `default` database exists since the start: https://github.com/AxaFrance/react-oidc/blob/3e535c94dc57d59956498bfa0ca9536106039bda/packages/react/service_worker/OidcServiceWorker.ts#L41

Which means it won't get properly initialized, so if you do something like this in `TrustedDomains.js`:

```js
const trustedDomains = {
    default: { domains: [ /* some domains */], showAccessToken: true }
}
```

the database for `default` won't show the access token anyway, since it's already initialized to hide the access token:
https://github.com/AxaFrance/react-oidc/blob/3e535c94dc57d59956498bfa0ca9536106039bda/packages/react/service_worker/OidcServiceWorker.ts#L50

I'm not 100% sure that it won't break something else (it seems not to!), but perhaps a maintainer could take a look.