### PR TITLE
Reclaming all clients from SW after hard reload

### DIFF
--- a/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
+++ b/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
@@ -283,6 +283,10 @@ const handleFetch = async (event: FetchEvent) => {
 const handleMessage = (event: ExtendableMessageEvent) => {
   const port = event.ports[0];
   const data = event.data as MessageEventData;
+  if (event.data.type === "claim") {
+    _self.clients.claim().then(() => port.postMessage({}));
+    return;
+  }
   const configurationName = data.configurationName;
   let currentDatabase = database[configurationName];
   if (trustedDomains == null) {

--- a/packages/oidc-client/public/OidcServiceWorker.js
+++ b/packages/oidc-client/public/OidcServiceWorker.js
@@ -427,10 +427,6 @@ const trustedDomainsShowAccessToken = {};
 const handleMessage = (event) => {
   const port = event.ports[0];
   const data = event.data;
-  if (event.data.type === "claim") {
-    _self.clients.claim().then(() => port.postMessage({}));
-    return;
-  }
   const configurationName = data.configurationName;
   let currentDatabase = database[configurationName];
   if (trustedDomains == null) {

--- a/packages/oidc-client/public/OidcServiceWorker.js
+++ b/packages/oidc-client/public/OidcServiceWorker.js
@@ -427,6 +427,10 @@ const trustedDomainsShowAccessToken = {};
 const handleMessage = (event) => {
   const port = event.ports[0];
   const data = event.data;
+  if (event.data.type === "claim") {
+    _self.clients.claim().then(() => port.postMessage({}));
+    return;
+  }
   const configurationName = data.configurationName;
   let currentDatabase = database[configurationName];
   if (trustedDomains == null) {

--- a/packages/oidc-client/src/initWorker.ts
+++ b/packages/oidc-client/src/initWorker.ts
@@ -189,6 +189,8 @@ export const initWorkerAsync = async(serviceWorkerRelativeUrl, configurationName
 
     try {
         await navigator.serviceWorker.ready;
+        if (!navigator.serviceWorker.controller)
+            await sendMessageAsync(registration)({ type: 'claim' });
     } catch (err) {
         return null;
     }


### PR DESCRIPTION
Detecting situation when service worker installed but does not control application(this is valid situation after hard refresh) and reclaiming control in response. Since this has to be done from within service worker itself have to send separate message to it.

## Before this PR
After Hard refresh we lose Bearer token injection for request. As a result you get 401 for most of request.

## After this PR
All works smooth

should fix #1098