### PR TITLE
feat(oidc-client): export OidcClient instance for client application

### DIFF
--- a/packages/react-oidc/src/index.ts
+++ b/packages/react-oidc/src/index.ts
@@ -9,4 +9,4 @@ export type {
   OidcConfiguration,
   StringMap,
 } from '@axa-fr/oidc-client';
-export { type OidcUserInfo, TokenRenewMode } from '@axa-fr/oidc-client';
+export { type OidcUserInfo, TokenRenewMode, OidcClient } from '@axa-fr/oidc-client';


### PR DESCRIPTION
This commit introduces the exportation of the OidcClient instance, making it available for use in the client-side application. The addition ensures seamless integration of authentication mechanisms and improves the overall flow of user authentication and authorization processes. 

Key Changes:
- Exported the OidcClient instance from the relevant module.
- Ensured compatibility and smooth integration with the client application.

Example of use without needing to use hooks in some cases

```
import { OidcClient } from '@axa-fr/react-oidc'

export const getTokens = () => {
  const { tokens } = OidcClient.get()
  return tokens
}

```

What do you think, @guillaume-chervet?