### PR TITLE
fix(oidc): parseJwt fails for some JWT because of wrong use of replace (alpha)

### DIFF
--- a/packages/oidc-client-service-worker/src/utils/__tests__/tokens.spec.ts
+++ b/packages/oidc-client-service-worker/src/utils/__tests__/tokens.spec.ts
@@ -35,7 +35,15 @@ describe('tokens', () => {
     it('parseJwtShouldExtractData', async () => {
       const claimsPart = "eyJzZXNzaW9uX3N0YXRlIjoiNzVjYzVlZDItZGYyZC00NTY5LWJmYzUtMThhOThlNjhiZTExIiwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJuYW1lIjoixrTHosOBw6zDhyDlsI_lkI0t44Ob44Or44OYIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdGluZ2NoYXJhY3RlcnNAaW52ZW50ZWRtYWlsLmNvbSIsImdpdmVuX25hbWUiOiLGtMeiw4HDrMOHIiwiZmFtaWx5X25hbWUiOiLlsI_lkI0t44Ob44Or44OYIn0"
       const result = parseJwt(claimsPart);
-      expect(result!=null).toBe(true);
+      expect(result).toStrictEqual({
+        "session_state": "75cc5ed2-df2d-4569-bfc5-18a98e68be11",
+        "scope": "openid email profile",
+        "email_verified": true,
+        "name": "ƴǢÁìÇ 小名-ホルヘ",
+        "preferred_username": "testingcharacters@inventedmail.com",
+        "given_name": "ƴǢÁìÇ",
+        "family_name": "小名-ホルヘ"
+      });
     });
     
     it('can extract token payload', () => {

--- a/packages/oidc-client-service-worker/src/utils/__tests__/tokens.spec.ts
+++ b/packages/oidc-client-service-worker/src/utils/__tests__/tokens.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { OidcServerConfiguration } from '../../types';
-import { _hideTokens, extractTokenPayload, isTokensOidcValid, isTokensValid } from '..';
+import {_hideTokens, extractTokenPayload, isTokensOidcValid, isTokensValid, parseJwt} from '..';
 import { OidcConfigBuilder, OidcServerConfigBuilder, TokenBuilder } from './testHelper';
 
 describe('tokens', () => {
@@ -31,6 +31,13 @@ describe('tokens', () => {
   });
 
   describe('extractTokenPayload', () => {
+
+    it('parseJwtShouldExtractData', async () => {
+      const claimsPart = "eyJzZXNzaW9uX3N0YXRlIjoiNzVjYzVlZDItZGYyZC00NTY5LWJmYzUtMThhOThlNjhiZTExIiwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJuYW1lIjoixrTHosOBw6zDhyDlsI_lkI0t44Ob44Or44OYIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdGluZ2NoYXJhY3RlcnNAaW52ZW50ZWRtYWlsLmNvbSIsImdpdmVuX25hbWUiOiLGtMeiw4HDrMOHIiwiZmFtaWx5X25hbWUiOiLlsI_lkI0t44Ob44Or44OYIn0"
+      const result = parseJwt(claimsPart);
+      expect(result!=null).toBe(true);
+    });
+    
     it('can extract token payload', () => {
       const result = extractTokenPayload(
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',

--- a/packages/oidc-client-service-worker/src/utils/tokens.ts
+++ b/packages/oidc-client-service-worker/src/utils/tokens.ts
@@ -12,7 +12,7 @@ import { countLetter } from './strings';
 
 function parseJwt(token: string) {
   return JSON.parse(
-    b64DecodeUnicode(token.split('.')[1].replace('-', '+').replace('_', '/')),
+    b64DecodeUnicode(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')),
   );
 }
 function b64DecodeUnicode(str: string) {

--- a/packages/oidc-client-service-worker/src/utils/tokens.ts
+++ b/packages/oidc-client-service-worker/src/utils/tokens.ts
@@ -10,9 +10,9 @@ import {
 } from '../types';
 import { countLetter } from './strings';
 
-function parseJwt(token: string) {
+export const parseJwt = (payload: string) => {
   return JSON.parse(
-    b64DecodeUnicode(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')),
+    b64DecodeUnicode(payload.replace(/-/g, '+').replace(/_/g, '/')),
   );
 }
 function b64DecodeUnicode(str: string) {
@@ -51,7 +51,7 @@ const extractTokenPayload = (token?: string) => {
       return null;
     }
     if (countLetter(token, '.') === 2) {
-      return parseJwt(token);
+      return parseJwt(token.split('.')[1]);
     } else {
       return null;
     }

--- a/packages/oidc-client/src/parseTokens.spec.ts
+++ b/packages/oidc-client/src/parseTokens.spec.ts
@@ -1,6 +1,6 @@
 ﻿import { describe, expect,it } from 'vitest';
 
-import {getValidTokenAsync, isTokensOidcValid, parseOriginalTokens} from "./parseTokens";
+import { getValidTokenAsync, isTokensOidcValid, parseJwt, parseOriginalTokens} from "./parseTokens";
 
 describe('ParseTokens test Suite', () => {
     const currentTimeUnixSecond = new Date().getTime() / 1000;
@@ -23,6 +23,12 @@ describe('ParseTokens test Suite', () => {
             const result = await getValidTokenAsync(oidc, 1, 1);
             expect(result.isTokensValid).toEqual(expectIsValidToken);
         });
+    });
+
+    it('parseJwtShouldExtractData', async () => {
+        const claimsPart = "eyJzZXNzaW9uX3N0YXRlIjoiNzVjYzVlZDItZGYyZC00NTY5LWJmYzUtMThhOThlNjhiZTExIiwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJuYW1lIjoixrTHosOBw6zDhyDlsI_lkI0t44Ob44Or44OYIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdGluZ2NoYXJhY3RlcnNAaW52ZW50ZWRtYWlsLmNvbSIsImdpdmVuX25hbWUiOiLGtMeiw4HDrMOHIiwiZmFtaWx5X25hbWUiOiLlsI_lkI0t44Ob44Or44OYIn0"
+        const result = parseJwt(claimsPart);
+        expect(result!=null).toBe(true);
     });
 
 

--- a/packages/oidc-client/src/parseTokens.spec.ts
+++ b/packages/oidc-client/src/parseTokens.spec.ts
@@ -28,7 +28,15 @@ describe('ParseTokens test Suite', () => {
     it('parseJwtShouldExtractData', async () => {
         const claimsPart = "eyJzZXNzaW9uX3N0YXRlIjoiNzVjYzVlZDItZGYyZC00NTY5LWJmYzUtMThhOThlNjhiZTExIiwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJuYW1lIjoixrTHosOBw6zDhyDlsI_lkI0t44Ob44Or44OYIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdGluZ2NoYXJhY3RlcnNAaW52ZW50ZWRtYWlsLmNvbSIsImdpdmVuX25hbWUiOiLGtMeiw4HDrMOHIiwiZmFtaWx5X25hbWUiOiLlsI_lkI0t44Ob44Or44OYIn0"
         const result = parseJwt(claimsPart);
-        expect(result!=null).toBe(true);
+        expect(result).toStrictEqual({
+            "session_state": "75cc5ed2-df2d-4569-bfc5-18a98e68be11",
+            "scope": "openid email profile",
+            "email_verified": true,
+            "name": "ƴǢÁìÇ 小名-ホルヘ",
+            "preferred_username": "testingcharacters@inventedmail.com",
+            "given_name": "ƴǢÁìÇ",
+            "family_name": "小名-ホルヘ"
+        });
     });
 
 

--- a/packages/oidc-client/src/parseTokens.ts
+++ b/packages/oidc-client/src/parseTokens.ts
@@ -2,7 +2,7 @@ import {sleepAsync} from './initWorker.js';
 
 const b64DecodeUnicode = (str) =>
     decodeURIComponent(Array.prototype.map.call(atob(str), (c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
-const parseJwt = (token) => JSON.parse(b64DecodeUnicode(token.split('.')[1].replace('-', '+').replace('_', '/')));
+const parseJwt = (token) => JSON.parse(b64DecodeUnicode(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
 
 const extractTokenPayload = (token) => {
     try {

--- a/packages/oidc-client/src/parseTokens.ts
+++ b/packages/oidc-client/src/parseTokens.ts
@@ -2,15 +2,15 @@ import {sleepAsync} from './initWorker.js';
 
 const b64DecodeUnicode = (str) =>
     decodeURIComponent(Array.prototype.map.call(atob(str), (c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
-const parseJwt = (token) => JSON.parse(b64DecodeUnicode(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+export const parseJwt = (payload:string) => JSON.parse(b64DecodeUnicode(payload.replace(/-/g, '+').replace(/_/g, '/')));
 
-const extractTokenPayload = (token) => {
+const extractTokenPayload = (token:string) => {
     try {
         if (!token) {
             return null;
         }
         if (countLetter(token, '.') === 2) {
-            return parseJwt(token);
+            return parseJwt(token.split('.')[1]);
         } else {
             return null;
         }


### PR DESCRIPTION
fix #1268
