### PR TITLE
fix: normalize userinfo endpoint in service worker

### DIFF
--- a/packages/oidc-client-service-worker/src/utils/__tests__/domains.spec.ts
+++ b/packages/oidc-client-service-worker/src/utils/__tests__/domains.spec.ts
@@ -101,6 +101,14 @@ describe('domains', () => {
 			expect(getCurrentDatabaseDomain(db, url, trustedDomains)).not.toBeNull();
 		});
 
+		it('will not return null, url is the userinfo endpoint on other domain, default port is set', () => {
+			db['default'].oidcServerConfiguration!.userInfoEndpoint =
+				'https://otherdomain.com:443/connect/userinfo';
+
+			const url = 'https://otherdomain.com/connect/userinfo';
+			expect(getCurrentDatabaseDomain(db, url, null)).not.toBeNull();
+		});
+
 		it('will test urls against domains list if accessTokenDomains list is not present', () => {
 			const trustedDomains: TrustedDomains = {
 				default: {

--- a/packages/oidc-client-service-worker/src/utils/domains.ts
+++ b/packages/oidc-client-service-worker/src/utils/domains.ts
@@ -36,8 +36,6 @@ export const getDomains = (
 	return trustedDomain[`${type}Domains`] ?? trustedDomain.domains ?? [];
 };
 
-
-
 export const getCurrentDatabaseDomain = (
 	database: Database,
 	url: string,
@@ -69,7 +67,7 @@ export const getCurrentDatabaseDomain = (
 
 		const domains = getDomains(trustedDomain, 'accessToken');
 		const domainsToSendTokens = oidcServerConfiguration.userInfoEndpoint
-			? [oidcServerConfiguration.userInfoEndpoint, ...domains]
+			? [normalizeUrl(oidcServerConfiguration.userInfoEndpoint), ...domains]
 			: [...domains];
 
 		let hasToSendToken = false;


### PR DESCRIPTION
## Before this PR

User info with port will not replace the access token.

## After this PR

User info with port will now properly forward the access token.
