### PR TITLE
fix(oidc): decrease minSleepSeconds value to prevent falsy errors and logs (alpha)

### DIFF
--- a/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
+++ b/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
@@ -85,12 +85,10 @@ const keepAliveAsync = async (event: FetchEvent) => {
 	if (!isFromVanilla) {
 		const originalRequestUrl = new URL(originalRequest.url);
 		const minSleepSeconds =
-			Number(originalRequestUrl.searchParams.get('minSleepSeconds')) || 240;
-		for (let i = 0; i < minSleepSeconds; i++) {
-			await sleep(1000 + Math.floor(Math.random() * 1000));
-			const cache = await caches.open('oidc_dummy_cache');
-			await cache.put(event.request, response.clone());
-		}
+			Number(originalRequestUrl.searchParams.get('minSleepSeconds')) || 20;
+		await sleep(minSleepSeconds * 1000 + Math.floor(Math.random() * 2000));
+		const cache = await caches.open('oidc_dummy_cache');
+		await cache.put(event.request, response.clone());
 	}
 	return response;
 };

--- a/packages/oidc-client/src/initWorker.ts
+++ b/packages/oidc-client/src/initWorker.ts
@@ -12,7 +12,7 @@ export const sleepAsync = ({milliseconds}: { milliseconds: any }) => {
 
 const keepAlive = (service_worker_keep_alive_path='/') => {
     try {
-        const minSleepSeconds =  150;
+        const minSleepSeconds =  20;
         keepAliveController = new AbortController();
         const promise = fetch(`${service_worker_keep_alive_path}OidcKeepAliveServiceWorker.json?minSleepSeconds=${minSleepSeconds}`, { signal: keepAliveController.signal });
         promise.catch(error => { console.log(error); });


### PR DESCRIPTION
This should fix #1350 

## A picture tells a thousand words

## Before this PR

`minSleepSeconds` parameter was set to 150, which caused issues on some browsers. A lot of errors (that don't have any impact on functionality) originating from keep-alive requests were logged.

## After this PR

`minSleepSeconds` parameter is decreased to 20, which is a safe value. It should prevent falsy errors from displaying.