### PR TITLE
build(pipeline): Update actions to non-deprecated versions. bump node version to 20.  Run tests in non-wait mode

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-rock-0dc6b0d03.yml
+++ b/.github/workflows/azure-static-web-apps-black-rock-0dc6b0d03.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   PNPM_VERSION: 8.6.11
-  NODE_VERSION: 18
+  NODE_VERSION: 20
 jobs:
   skip_ci:
     runs-on: ubuntu-latest
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/azure-static-web-apps-icy-glacier-004ab4303.yml
+++ b/.github/workflows/azure-static-web-apps-icy-glacier-004ab4303.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   PNPM_VERSION: 8.6.11
-  NODE_VERSION: 18
+  NODE_VERSION: 20
 jobs:
   skip_ci:
     runs-on: ubuntu-latest
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,17 @@ on:
 
 env:
   PNPM_VERSION: 8.6.11
-  NODE_VERSION: 18
+  NODE_VERSION: 20
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -40,7 +40,7 @@ jobs:
         working-directory: ./packages/oidc-client
 
       - name: Run test (oidc-client)
-        run: pnpm test -- --run
+        run: pnpm test
         working-directory: ./packages/oidc-client
 
       #react-oidc
@@ -53,5 +53,5 @@ jobs:
         working-directory: ./packages/react-oidc
 
       - name: Run test (react-oidc)
-        run: pnpm test -- --run
+        run: pnpm test
         working-directory: ./packages/react-oidc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   PNPM_VERSION: 8.6.11
-  NODE_VERSION: 18    
+  NODE_VERSION: 20
 
 jobs:
   run-linters:
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   PNPM_VERSION: 8.6.11
-  NODE_VERSION: 18
+  NODE_VERSION: 20
 jobs:
   skip_ci:
     runs-on: ubuntu-latest
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.skip_ci.outputs.canSkip != 'true' && github.event.pull_request.head.repo.fork
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -44,7 +44,7 @@ jobs:
         working-directory: ./packages/react-oidc
 
       - name: pnpm test
-        run: pnpm test -- --run
+        run: pnpm test
         working-directory: ./packages/react-oidc
 
       - name: pnpm install
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.skip_ci.outputs.canSkip != 'true' && !github.event.pull_request.head.repo.fork
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GIT_TOKEN }}
           fetch-depth: 0
@@ -152,7 +152,7 @@ jobs:
         working-directory: ./packages/oidc-client-service-worker
         
       - name: pnpm test
-        run: pnpm test -- --run
+        run: pnpm test
         working-directory: ./packages/oidc-client-service-worker
         
       # oidc-client
@@ -196,7 +196,7 @@ jobs:
         working-directory: ./packages/react-oidc
 
       - name: pnpm test
-        run: pnpm test -- --run
+        run: pnpm test
         working-directory: ./packages/react-oidc
         
       # oidc-client-service-worker

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --cache .",
     "lint-fix": "eslint --cache --fix .",
     "outdated": "pnpm outdated -r",
-    "test": "pnpm run test --workspaces --if-present",
+    "test": "pnpm --if-present --recursive run test ",
     "build": "pnpm -r --filter=./packages/* run build"
   },
   "devDependencies": {

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -48,7 +48,7 @@
     "clean": "rimraf dist",
     "copy-service-worker": "cpy ./node_modules/@axa-fr/oidc-client-service-worker/dist/OidcTrustedDomains.js ./node_modules/@axa-fr/oidc-client-service-worker/dist/OidcServiceWorker.js ./dist",
     "build": "tsc && vite build",
-    "test": "vitest --root . --coverage",
+    "test": "vitest run --root . --coverage",
     "prepare": "pnpm run clean && pnpm run copy-service-worker && pnpm run build",
     "postinstall": "echo 'WARNING keep sink OidcServiceWorker.js version file'"
   },

--- a/packages/react-oidc/package.json
+++ b/packages/react-oidc/package.json
@@ -33,7 +33,7 @@
     "start": "pnpm run copy-service-worker && vite",
     "build": "vite build",
     "serve": "vite preview",
-    "test": "vitest --root . --coverage",
+    "test": "vitest run --root . --coverage",
     "clean": "rimraf dist",
     "postinstall": "echo 'WARNING keep sink OidcServiceWorker.js version file'",
     "prepare": "pnpm run clean && pnpm run copy-service-worker && pnpm run build",


### PR DESCRIPTION
- Update github actions to later versions (avoids the deprecated warning with node 18)
- Set Node version to `20` (from `18`) in pipeline
- modify test action in `package.json` to run in non-watch mode, so tests can be triggered from root workspace with `pnpm test` . 
  - simplify pipeline to just be `pnpm test`
