### PR TITLE
tests(domain): Be more explicit about intent of test

### DIFF
--- a/packages/oidc-client-service-worker/src/utils/__tests__/domains.spec.ts
+++ b/packages/oidc-client-service-worker/src/utils/__tests__/domains.spec.ts
@@ -1,21 +1,21 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { openidWellknownUrlEndWith } from '../../constants';
+import { Database, Tokens, TrustedDomains } from '../../types';
 import { checkDomain, getCurrentDatabaseDomain } from '..';
-import { Database, Tokens, TrustedDomains } from './../../types';
 
 describe('domains', () => {
 	describe('can check domain matches', () => {
-		it('can check string domains and return void', () => {
-			const result = () =>
+		it('can check string domains without throwing an exception', () => {
+			expect(() => {
 				checkDomain(['https://securesite.com:3000'], 'https://securesite.com:3000');
-			expect(result()).toBeUndefined();
+			}).not.toThrow();
 		});
 
-		it('can check regExp domains and return void when valid', () => {
-			const result = () =>
+		it('can check regExp domains without throwing an exception when valid', () => {
+			expect(() => {
 				checkDomain([/^https:\/\/securesite\.com/], 'https://securesite.com:3000');
-			expect(result()).toBeUndefined();
+			}).not.toThrow();
 		});
 
 		it('will throw error when domain is not trusted', () => {
@@ -24,9 +24,10 @@ describe('domains', () => {
 			expect(result).toThrowError();
 		});
 
-		it('will return void when endpoint is falsy', () => {
-			const result = () => checkDomain(['https://securesite.com:3000'], '');
-			expect(result()).toBeUndefined();
+		it('will not throw an exception when endpoint is falsy', () => {
+			expect(() => {
+				checkDomain(['https://securesite.com:3000'], '');
+			}).not.toThrow();
 		});
 	});
 	describe('getCurrentDatabaseDomain', () => {


### PR DESCRIPTION
Tests are verifying no exception is thrown, not that the response is void. Changed to be more explicit about intent.