### PR TITLE
fix (FetchToken): Fix FetchToken param to be boolean instead of false (release)

### DIFF
--- a/packages/oidc-client/src/oidcClient.ts
+++ b/packages/oidc-client/src/oidcClient.ts
@@ -75,7 +75,7 @@ export class OidcClient {
         return getValidTokenAsync(this._oidc, waitMs, numberWait);
     }
     
-    fetchWithTokens(fetch: Fetch, demonstrating_proof_of_possession:false): Fetch {
+    fetchWithTokens(fetch: Fetch, demonstrating_proof_of_possession:boolean = false): Fetch {
         return fetchWithTokens(fetch, this, demonstrating_proof_of_possession);
     }
 

--- a/packages/react-oidc/src/FetchToken.tsx
+++ b/packages/react-oidc/src/FetchToken.tsx
@@ -7,7 +7,7 @@ export interface ComponentWithOidcFetchProps {
 
 const defaultConfigurationName = 'default';
 
-const fetchWithToken = (fetch: Fetch, getOidcWithConfigurationName: () => OidcClient | null, demonstrating_proof_of_possession=false) => async (...params: Parameters<Fetch>) => {
+const fetchWithToken = (fetch: Fetch, getOidcWithConfigurationName: () => OidcClient | null, demonstrating_proof_of_possession: boolean = false) => async (...params: Parameters<Fetch>) => {
   const oidc = getOidcWithConfigurationName();
   const newFetch = oidc.fetchWithTokens(fetch, demonstrating_proof_of_possession);
   return await newFetch(...params);


### PR DESCRIPTION
Change type of param to boolean (default: false) to resolve compile error:

```text
packages/react-oidc prepare: src/FetchToken.tsx:12:48 - error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'false'.
packages/react-oidc prepare: 12   const newFetch = oidc.fetchWithTokens(fetch, demonstrating_proof_of_possession);
```

https://github.com/AxaFrance/oidc-client/actions/runs/9913967120/job/27392088934#step:6:121

