### PR TITLE
Minor refactor , possible breaking change for eventNames.token_aquired rename

### DIFF
--- a/packages/oidc-client/src/events.ts
+++ b/packages/oidc-client/src/events.ts
@@ -1,6 +1,6 @@
 export const eventNames = {
   service_worker_not_supported_by_browser: 'service_worker_not_supported_by_browser',
-  token_aquired: 'token_aquired',
+  token_acquired: 'token_acquired',
   logout_from_another_tab: 'logout_from_another_tab',
   logout_from_same_tab: 'logout_from_same_tab',
   token_renewed: 'token_renewed',

--- a/packages/oidc-client/src/initWorker.ts
+++ b/packages/oidc-client/src/initWorker.ts
@@ -63,7 +63,7 @@ const sendMessageAsync =
     return new Promise(function (resolve, reject) {
       const messageChannel = new MessageChannel();
       messageChannel.port1.onmessage = function (event) {
-        if (event.data && event.data.error) {
+        if (event?.data.error) {
           reject(event.data.error);
         } else {
           resolve(event.data);

--- a/packages/oidc-client/src/oidc.ts
+++ b/packages/oidc-client/src/oidc.ts
@@ -349,7 +349,7 @@ Please checkout that you are using OIDC hook inside a <OidcProvider configuratio
         const session = initSession(this.configurationName, this.configuration.storage);
         session.setTokens(parsedTokens);
       }
-      this.publishEvent(Oidc.eventNames.token_aquired, parsedTokens);
+      this.publishEvent(Oidc.eventNames.token_acquired, parsedTokens);
       if (this.configuration.preload_user_info) {
         await this.userInfoAsync();
       }

--- a/packages/oidc-client/src/renewTokens.ts
+++ b/packages/oidc-client/src/renewTokens.ts
@@ -13,10 +13,10 @@ async function syncTokens(oidc: Oidc, forceRefresh: boolean, extras: StringMap) 
     oidc.tokens = tokens;
   };
   const { tokens, status } = await synchroniseTokensAsync(oidc)(
+    updateTokens,
     0,
     forceRefresh,
     extras,
-    updateTokens,
   );
 
   const serviceWorker = await initWorkerAsync(oidc.configuration, oidc.configurationName);
@@ -200,7 +200,7 @@ export const syncTokensInfoAsync =
 
 const synchroniseTokensAsync =
   (oidc: Oidc) =>
-  async (index = 0, forceRefresh = false, extras: StringMap = null, updateTokens) => {
+  async (updateTokens, index = 0, forceRefresh = false, extras: StringMap = null) => {
     if (!navigator.onLine && document.hidden) {
       return { tokens: oidc.tokens, status: 'GIVE_UP' };
     }
@@ -264,7 +264,7 @@ const synchroniseTokensAsync =
           message: 'exceptionSilent',
           exception: exceptionSilent.message,
         });
-        return await synchroniseTokensAsync(oidc)(nextIndex, forceRefresh, extras, updateTokens);
+        return await synchroniseTokensAsync(oidc)(updateTokens, nextIndex, forceRefresh, extras);
       }
     };
 
@@ -422,10 +422,10 @@ const synchroniseTokensAsync =
               }
 
               return await synchroniseTokensAsync(oidc)(
+                updateTokens,
                 nextIndex,
                 forceRefresh,
                 extras,
-                updateTokens,
               );
             }
           };
@@ -443,7 +443,7 @@ const synchroniseTokensAsync =
       // so we need to brake calls chain and delay next call
       return new Promise((resolve, reject) => {
         setTimeout(() => {
-          synchroniseTokensAsync(oidc)(nextIndex, forceRefresh, extras, updateTokens)
+          synchroniseTokensAsync(oidc)(updateTokens, nextIndex, forceRefresh, extras)
             .then(resolve)
             .catch(reject);
         }, 1000);

--- a/packages/oidc-client/src/silentLogin.ts
+++ b/packages/oidc-client/src/silentLogin.ts
@@ -168,7 +168,7 @@ export const defaultSilentLoginAsync =
 
         if (silentResult) {
           oidc.tokens = silentResult.tokens;
-          publishEvent(eventNames.token_aquired, {});
+          publishEvent(eventNames.token_acquired, {});
           // @ts-ignore
           oidc.timeoutId = autoRenewTokens(oidc, oidc.tokens.expiresAt, extras);
           return {};

--- a/packages/react-oidc/src/ReactOidc.tsx
+++ b/packages/react-oidc/src/ReactOidc.tsx
@@ -31,7 +31,7 @@ export const useOidc = (configurationName = defaultConfigurationName) => {
       if (
         name === OidcClient.eventNames.logout_from_another_tab ||
         name === OidcClient.eventNames.logout_from_same_tab ||
-        name === OidcClient.eventNames.token_aquired
+        name === OidcClient.eventNames.token_acquired
       ) {
         if (isMounted) {
           setIsAuthenticated(defaultIsAuthenticated(getOidc, configurationName));
@@ -131,7 +131,7 @@ export const useOidcAccessToken = (configurationName = defaultConfigurationName)
     const newSubscriptionId = oidc.subscribeEvents((name: string, data: any) => {
       if (
         name === OidcClient.eventNames.token_renewed ||
-        name === OidcClient.eventNames.token_aquired ||
+        name === OidcClient.eventNames.token_acquired ||
         name === OidcClient.eventNames.logout_from_another_tab ||
         name === OidcClient.eventNames.logout_from_same_tab ||
         name === OidcClient.eventNames.refreshTokensAsync_error ||
@@ -193,7 +193,7 @@ export const useOidcIdToken = (configurationName = defaultConfigurationName) => 
     const newSubscriptionId = oidc.subscribeEvents((name: string, data: any) => {
       if (
         name === OidcClient.eventNames.token_renewed ||
-        name === OidcClient.eventNames.token_aquired ||
+        name === OidcClient.eventNames.token_acquired ||
         name === OidcClient.eventNames.logout_from_another_tab ||
         name === OidcClient.eventNames.logout_from_same_tab ||
         name === OidcClient.eventNames.refreshTokensAsync_error ||


### PR DESCRIPTION
- fix spelling `token_acquired`
- refactor(parameters): Default parameters should be last.sonarlint(typescript:S1788)
- refactor(initWorker): null coalescing

this will be a breaking change if consumers reference `eventNames.token_aquired`