### PR TITLE
fix(oidc): record tabIds when service worker receives init event (release)

### DIFF
--- a/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
+++ b/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
@@ -184,7 +184,7 @@ const handleFetch = async (event: FetchEvent) => {
           let newBody = actualBody;
           for (let i = 0; i < numberDatabase; i++) {
             const currentDb = currentDatabases[i];
-            const currentDbTabs = Object.keys(currentDb.state);
+            const currentDbTabs = currentDb.tabIds;
 
             if (currentDb?.tokens != null) {
               const claimsExtras = {
@@ -338,6 +338,7 @@ const handleMessage = async (event: ExtendableMessageEvent) => {
       : trustedDomain.allowMultiTabLogin;
     database[configurationName] = {
       tokens: null,
+      tabIds: [],
       state: {},
       codeVerifier: {},
       oidcServerConfiguration: null,
@@ -366,6 +367,7 @@ const handleMessage = async (event: ExtendableMessageEvent) => {
   switch (data.type) {
     case 'clear':
       currentDatabase.tokens = null;
+      currentDatabase.tabIds = [];
       currentDatabase.state = {};
       currentDatabase.codeVerifier = {};
       currentDatabase.demonstratingProofOfPossessionNonce = null;
@@ -391,6 +393,9 @@ const handleMessage = async (event: ExtendableMessageEvent) => {
       }
       currentDatabase.oidcServerConfiguration = oidcServerConfiguration;
       currentDatabase.oidcConfiguration = data.data.oidcConfiguration;
+      if (!currentDatabase.tabIds.includes(tabId)) {
+        currentDatabase.tabIds.push(tabId);
+      }
 
       if (currentDatabase.demonstratingProofOfPossessionConfiguration == null) {
         const demonstratingProofOfPossessionConfiguration = getDpopConfiguration(

--- a/packages/oidc-client-service-worker/src/__tests__/oidcConfig.spec.ts
+++ b/packages/oidc-client-service-worker/src/__tests__/oidcConfig.spec.ts
@@ -7,6 +7,7 @@ const oidcConfigDefaults = {
   demonstratingProofOfPossessionConfiguration: null,
   configurationName: '',
   tokens: null,
+  tabIds: [],
   status: null,
   state: {},
   codeVerifier: {},

--- a/packages/oidc-client-service-worker/src/types.ts
+++ b/packages/oidc-client-service-worker/src/types.ts
@@ -101,6 +101,7 @@ export type Nonce = {
 export type OidcConfig = {
   demonstratingProofOfPossessionConfiguration: DemonstratingProofOfPossessionConfiguration | null;
   configurationName: string;
+  tabIds: string[];
   tokens: Tokens | null;
   status: Status;
   state: Record<string, string | null>;

--- a/packages/oidc-client-service-worker/src/utils/__tests__/domains.spec.ts
+++ b/packages/oidc-client-service-worker/src/utils/__tests__/domains.spec.ts
@@ -38,6 +38,7 @@ describe('domains', () => {
         default: {
           configurationName: 'config',
           tokens: {} as Tokens,
+          tabIds: [],
           status: 'NOT_CONNECTED',
           state: {},
           codeVerifier: {},

--- a/packages/oidc-client-service-worker/src/utils/__tests__/testHelper.ts
+++ b/packages/oidc-client-service-worker/src/utils/__tests__/testHelper.ts
@@ -111,6 +111,7 @@ class OidcConfigBuilder {
   private oidcConfig: OidcConfig = {
     configurationName: '',
     tokens: null,
+    tabIds: [],
     status: 'NOT_CONNECTED',
     state: { tab1: '' },
     codeVerifier: { tab1: '' },


### PR DESCRIPTION
Fix from https://github.com/AxaFrance/oidc-client/pull/1402 has one issue - if `allowMultiTabLogin` flag is true and second tab is opened (when first tab is already authenticated), trying to initiate token renewal (using refresh token) from second tab fails. This is because previously tabId was saved to database only when login flow was initiated from given tab. This fix adds registering of tab id each time service worker receives `init` event.

## A picture tells a thousand words

## Before this PR

## After this PR
