### PR TITLE
fix(oidc): Add null as union type into arguments for login, logout, renewTokens

### DIFF
--- a/packages/react-oidc/src/ReactOidc.tsx
+++ b/packages/react-oidc/src/ReactOidc.tsx
@@ -46,7 +46,7 @@ export const useOidc = (configurationName = defaultConfigurationName) => {
 
   const login = (
     callbackPath: string | undefined = undefined,
-    extras: StringMap = null,
+    extras: StringMap | null = null,
     silentLoginOnly = false,
   ) => {
     return getOidc(configurationName).loginAsync(
@@ -59,11 +59,13 @@ export const useOidc = (configurationName = defaultConfigurationName) => {
   };
   const logout = (
     callbackPath: string | null | undefined = undefined,
-    extras: StringMap = null,
+    extras: StringMap | null = null,
   ) => {
     return getOidc(configurationName).logoutAsync(callbackPath, extras);
   };
-  const renewTokens = async (extras: StringMap = null): Promise<OidcAccessToken | OidcIdToken> => {
+  const renewTokens = async (
+    extras: StringMap | null = null,
+  ): Promise<OidcAccessToken | OidcIdToken> => {
     const tokens = await getOidc(configurationName).renewTokensAsync(extras);
 
     return {


### PR DESCRIPTION
## A picture tells a thousand words

The TS2322 error occurs in `ReactOidc.tsx` because the type of the extras parameter only accepts `StringMap`. 
I think it should include `null` as a union.

## Before this PR

The TS2322 error occurs in `ReactOidc.tsx`

## After this PR

will prevent the error from occurring