### PR TITLE
fix(oidc): Add undefined as union type into arguments for login, logout, renewTokens

### DIFF
--- a/packages/react-oidc/src/ReactOidc.tsx
+++ b/packages/react-oidc/src/ReactOidc.tsx
@@ -46,7 +46,7 @@ export const useOidc = (configurationName = defaultConfigurationName) => {
 
   const login = (
     callbackPath: string | undefined = undefined,
-    extras: StringMap = null,
+    extras: StringMap | null = null,
     silentLoginOnly = false,
   ) => {
     return getOidc(configurationName).loginAsync(
@@ -59,11 +59,13 @@ export const useOidc = (configurationName = defaultConfigurationName) => {
   };
   const logout = (
     callbackPath: string | null | undefined = undefined,
-    extras: StringMap = null,
+    extras: StringMap | null = null,
   ) => {
     return getOidc(configurationName).logoutAsync(callbackPath, extras);
   };
-  const renewTokens = async (extras: StringMap = null): Promise<OidcAccessToken | OidcIdToken> => {
+  const renewTokens = async (
+    extras: StringMap | null = null,
+  ): Promise<OidcAccessToken | OidcIdToken> => {
     const tokens = await getOidc(configurationName).renewTokensAsync(extras);
 
     return {

--- a/packages/react-oidc/src/ReactOidc.tsx
+++ b/packages/react-oidc/src/ReactOidc.tsx
@@ -46,7 +46,7 @@ export const useOidc = (configurationName = defaultConfigurationName) => {
 
   const login = (
     callbackPath: string | undefined = undefined,
-    extras: StringMap | null = null,
+    extras: StringMap | undefined = undefined,
     silentLoginOnly = false,
   ) => {
     return getOidc(configurationName).loginAsync(
@@ -59,12 +59,12 @@ export const useOidc = (configurationName = defaultConfigurationName) => {
   };
   const logout = (
     callbackPath: string | null | undefined = undefined,
-    extras: StringMap | null = null,
+    extras: StringMap | undefined = undefined,
   ) => {
     return getOidc(configurationName).logoutAsync(callbackPath, extras);
   };
   const renewTokens = async (
-    extras: StringMap | null = null,
+    extras: StringMap | undefined = undefined,
   ): Promise<OidcAccessToken | OidcIdToken> => {
     const tokens = await getOidc(configurationName).renewTokensAsync(extras);
 


### PR DESCRIPTION
# A picture tells a thousand words

I've modified default value as null for `extras` parameters in login, logout, renewTokens  https://github.com/AxaFrance/oidc-client/pull/1427
But I realized that they shoud be `undefined` because loginAsync,logoutAsync,renewTokensAsync accept `extras` as option.

# Before this PR

TS2345 erro occur in `ReactOidc.tsx`

# After this PR

will prevent the error from occurring