### PR TITLE
fix(logout): should work correctly with multiple tabs (release)

### DIFF
--- a/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
+++ b/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
@@ -367,9 +367,11 @@ const handleMessage = async (event: ExtendableMessageEvent) => {
   switch (data.type) {
     case 'clear':
       currentDatabase.tokens = null;
-      currentDatabase.tabIds = [];
-      currentDatabase.state = {};
-      currentDatabase.codeVerifier = {};
+      currentDatabase.tabIds = currentDatabase.tabIds.filter(id => id !== tabId);
+      delete currentDatabase.state[tabId];
+      delete currentDatabase.codeVerifier[tabId];
+      delete currentDatabase.nonce[tabId];
+
       currentDatabase.demonstratingProofOfPossessionNonce = null;
       currentDatabase.demonstratingProofOfPossessionJwkJson = null;
       currentDatabase.demonstratingProofOfPossessionConfiguration = null;


### PR DESCRIPTION
## Before this PR
If you have `allowMultiTabLogin` and you have few tabs opened, you can face issue with logout function.

As I found, after logout there are still couple of messages sent from client to serwiceWorker (init and setState, at least).
This leads to case, when `currentDatabase.state` is changed after you passed logout function, but before you get redirected back to login screen. (At lease I think this is a reason. If you have better ideas about how to fix this - please comment, this is interesting).

So when you try to login after logout, you receive 400 error from OAuth2 server, because client sends request with some data from previous session (which was closed obviously).
 
## After this PR
You can loggin back to app from any tab without errors