### PR TITLE
fix(oidc): force sw update when new registration appears (release)

### DIFF
--- a/examples/react-oidc-demo/package.json
+++ b/examples/react-oidc-demo/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/AxaGuilDEv/react-oidc.git"
   },
   "scripts": {
-    "start": "vite",
+    "start": "pnpm prestart && pnpm vite",
+    "prestart": "node ./node_modules/@axa-fr/react-oidc/bin/copy-service-worker-files.mjs public",
     "build": "vite build",
     "serve": "vite preview",
     "clean": "rimraf dist",

--- a/packages/oidc-client/src/initWorker.ts
+++ b/packages/oidc-client/src/initWorker.ts
@@ -113,6 +113,11 @@ export const initWorkerAsync = async (
     registration = await configuration.service_worker_register(serviceWorkerRelativeUrl);
   } else {
     registration = await navigator.serviceWorker.register(serviceWorkerRelativeUrl);
+
+    if (registration.active && registration.waiting) {
+      console.log('Detected new service worker waiting, unregistering and reloading');
+      await configuration.service_worker_update_require_callback?.(registration, stopKeepAlive);
+    }
   }
 
   try {
@@ -151,7 +156,7 @@ export const initWorkerAsync = async (
       console.warn(
         `Service worker ${serviceWorkerVersion} version mismatch with js client version ${codeVersion}, unregistering and reloading`,
       );
-      await oidcConfiguration.service_worker_update_require_callback(registration, stopKeepAlive);
+      await oidcConfiguration.service_worker_update_require_callback?.(registration, stopKeepAlive);
     }
 
     // @ts-ignore


### PR DESCRIPTION
Should help with https://github.com/AxaFrance/oidc-client/issues/1400

Also allow to update SW when some code changes happens within same version. At lest existing `service_worker_update_require_callback` was effective enough for me in private app tests and with react-oidc-demo app too. I didn't fail in any reload loop, since SW copy function was added to app prestart.

@piotrbartnik  @guillaume-chervet  would be great if you could prove that it works or not at yours environment

