### PR TITLE
fix(oidc): ensure unique tabIds when page is duplicated (beta)

### DIFF
--- a/packages/oidc-client/src/initWorker.ts
+++ b/packages/oidc-client/src/initWorker.ts
@@ -57,17 +57,8 @@ export const defaultServiceWorkerUpdateRequireCallback =
     location.reload();
   };
 
-const getTabId = (configurationName: string) => {
-  const tabId = sessionStorage.getItem(`oidc.tabId.${configurationName}`);
-
-  if (tabId) {
-    return tabId;
-  }
-
-  const newTabId = globalThis.crypto.randomUUID();
-  sessionStorage.setItem(`oidc.tabId.${configurationName}`, newTabId);
-  return newTabId;
-};
+const getTabId = (configurationName: string) =>
+  sessionStorage.getItem(`oidc.tabId.${configurationName}`);
 
 const sendMessageAsync =
   registration =>

--- a/packages/oidc-client/src/keepSession.ts
+++ b/packages/oidc-client/src/keepSession.ts
@@ -17,6 +17,7 @@ export const tryKeepSessionAsync = async (oidc: Oidc) => {
       configuration.authority,
       configuration.authority_configuration,
     );
+    await oidc.ensureUniqueTabId();
     serviceWorker = await initWorkerAsync(configuration, oidc.configurationName);
     if (serviceWorker) {
       const { tokens } = await serviceWorker.initAsync(

--- a/packages/oidc-client/src/login.ts
+++ b/packages/oidc-client/src/login.ts
@@ -114,6 +114,7 @@ export const loginCallbackAsync =
       const href = oidc.location.getCurrentHref();
       const queryParams = getParseQueryStringFromLocation(href);
       const sessionState = queryParams.session_state;
+      await oidc.ensureUniqueTabId();
       const serviceWorker = await initWorkerAsync(configuration, oidc.configurationName);
       let storage;
       let nonceData;

--- a/packages/oidc-client/src/logout.ts
+++ b/packages/oidc-client/src/logout.ts
@@ -44,6 +44,7 @@ export const destroyAsync = oidc => async status => {
   if (oidc.checkSessionIFrame) {
     oidc.checkSessionIFrame.stop();
   }
+  await oidc.ensureUniqueTabId();
   const serviceWorker = await initWorkerAsync(oidc.configuration, oidc.configurationName);
   if (!serviceWorker) {
     const session = initSession(oidc.configurationName, oidc.configuration.storage);

--- a/packages/oidc-client/src/oidc.ts
+++ b/packages/oidc-client/src/oidc.ts
@@ -96,6 +96,8 @@ export class Oidc {
   public checkSessionIFrame: CheckSessionIFrame;
   public getFetch: () => Fetch;
   public location: ILOidcLocation;
+  public tabId: string;
+  private channel: BroadcastChannel;
   constructor(
     configuration: OidcConfiguration,
     configurationName = 'default',
@@ -158,7 +160,50 @@ export class Oidc {
     this.destroyAsync.bind(this);
     this.logoutAsync.bind(this);
     this.renewTokensAsync.bind(this);
+    this.ensureUniqueTabId.bind(this);
     this.initAsync(this.configuration.authority, this.configuration.authority_configuration);
+  }
+
+  async ensureUniqueTabId() {
+    const generateUniqueTabId = () => {
+      const newTabId = globalThis.crypto.randomUUID();
+      sessionStorage.setItem(`oidc.tabId.${this.configurationName}`, newTabId);
+      this.tabId = newTabId;
+    };
+
+    if (!this.channel) {
+      this.channel = new BroadcastChannel(`oidc.broadcast-channel.${this.configurationName}`);
+      this.channel.onmessage = msg => {
+        const type = msg?.data?.type;
+        const tabId = msg?.data?.tabId;
+
+        if (tabId === this.tabId) {
+          if (type === 'SEARCH') {
+            this.channel.postMessage({ type: 'FOUND', tabId });
+          } else if (type === 'FOUND') {
+            generateUniqueTabId();
+          }
+        }
+      };
+    }
+
+    const tabId = sessionStorage.getItem(`oidc.tabId.${this.configurationName}`);
+
+    if (!tabId) {
+      generateUniqueTabId();
+      return;
+    }
+
+    this.channel.postMessage({ type: 'SEARCH', tabId });
+    await new Promise<void>(resolve =>
+      setTimeout(() => {
+        // if there is no tabId, it means that duplicate wasn't found
+        if (!this.tabId) {
+          this.tabId = tabId;
+        }
+        resolve();
+      }, 500),
+    );
   }
 
   subscribeEvents(func): string {
@@ -252,6 +297,7 @@ Please checkout that you are using OIDC hook inside a <OidcProvider configuratio
         });
       }
 
+      await this.ensureUniqueTabId();
       const serviceWorker = await initWorkerAsync(this.configuration, this.configurationName);
       const storage = serviceWorker ? window.localStorage : null;
       return await fetchFromIssuer(this.getFetch())(
@@ -311,6 +357,7 @@ Please checkout that you are using OIDC hook inside a <OidcProvider configuratio
     if (this.loginPromise !== null) {
       return this.loginPromise;
     }
+    await this.ensureUniqueTabId();
     if (silentLoginOnly) {
       this.loginPromise = defaultSilentLoginAsync(
         window,

--- a/packages/oidc-client/src/renewTokens.ts
+++ b/packages/oidc-client/src/renewTokens.ts
@@ -19,6 +19,7 @@ async function syncTokens(oidc: Oidc, forceRefresh: boolean, extras: StringMap) 
     extras,
   );
 
+  await oidc.ensureUniqueTabId();
   const serviceWorker = await initWorkerAsync(oidc.configuration, oidc.configurationName);
   if (!serviceWorker) {
     const session = initSession(oidc.configurationName, oidc.configuration.storage);
@@ -41,6 +42,7 @@ export async function renewTokensAndStartTimerAsync(
   const lockResourcesName = `${configuration.client_id}_${oidc.configurationName}_${configuration.authority}`;
 
   let tokens: null;
+  await oidc.ensureUniqueTabId();
   const serviceWorker = await initWorkerAsync(oidc.configuration, oidc.configurationName);
 
   if ((configuration?.storage === window?.sessionStorage && !serviceWorker) || !navigator.locks) {
@@ -120,6 +122,7 @@ export const syncTokensInfoAsync =
       configuration.authority,
       configuration.authority_configuration,
     );
+    await oidc.ensureUniqueTabId();
     const serviceWorker = await initWorkerAsync(configuration, configurationName);
     if (serviceWorker) {
       const { status, tokens } = await serviceWorker.initAsync(
@@ -214,6 +217,7 @@ const synchroniseTokensAsync =
     const localsilentLoginAsync = async () => {
       try {
         let loginParams;
+        await oidc.ensureUniqueTabId();
         const serviceWorker = await initWorkerAsync(configuration, oidc.configurationName);
         if (serviceWorker) {
           loginParams = serviceWorker.getLoginParams();
@@ -376,6 +380,7 @@ const synchroniseTokensAsync =
               }
               updateTokens(tokenResponse.data);
               if (tokenResponse.demonstratingProofOfPossessionNonce) {
+                await oidc.ensureUniqueTabId();
                 const serviceWorker = await initWorkerAsync(configuration, oidc.configurationName);
                 if (serviceWorker) {
                   await serviceWorker.setDemonstratingProofOfPossessionNonce(


### PR DESCRIPTION
## A picture tells a thousand words

This PR has the same changes as #1448, which was merged but then removed (see discussion in #1481).

See full description at #1448.

## Before this PR
When user duplicates a browser tab, session storage is copied so both tabs use the same `tabId`. Operations like login in one tab can override the state of another tab.

## After this PR
OIDC client can detect that the tab was duplicated and its `tabId` is already used.

