### PR TITLE
fix(renewTokens): prevent infinite loop on renew token flow

### DIFF
--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-fr/oidc-client",
-  "version": "7.25.13",
+  "version": "7.25.14",
   "private": false,
   "type": "module",
   "main": "./dist/index.umd.cjs",


### PR DESCRIPTION
Users who leave the application running in the background and subsequently lose VPN connectivity are generating excessive "Failed to fetch" errors in our observability logs. This issue arises because the application does not transition to the "Session Lost" state as expected, due to a flaw in the synchroniseTokensAsync function. Properly handling this scenario by moving affected sessions to the "Session Lost" state would mitigate unnecessary error logging.

## A picture tells a thousand words

## Before this PR

The synchroniseTokensAsync function in renewTokens.ts could enter an infinite loop when an error occurred during token renewal, as recursive calls to itself were made without a proper break  incrementing the "index" variable when the window document is hidden.

## After this PR

The implementation now prevents infinite recursion in synchroniseTokensAsync by breaking the call chain. This ensures that errors during token renewal do not cause stack overflow, improving reliability and browser stability.