### PR TITLE
Clear userInfo in storage in clearAsync function

### DIFF
--- a/packages/oidc-client/src/initSession.ts
+++ b/packages/oidc-client/src/initSession.ts
@@ -1,6 +1,7 @@
 export const initSession = (configurationName, storage = sessionStorage) => {
   const clearAsync = status => {
     storage[`oidc.${configurationName}`] = JSON.stringify({ tokens: null, status });
+    delete storage[`oidc.${configurationName}.userInfo`];
     return Promise.resolve();
   };
 


### PR DESCRIPTION
When using localStorage as the session storage, the userInfo stays present even after logging out. Due to this and with the recent addition of caching, invalid data gets eventually loaded from the localStorage (as there is no validation on load) and will display wrong information in some cases (e.g. user has switched account on the IdP).
