### PR TITLE
feat(react-oidc): enforce uniqueness of redirect_uri and silent_redirect_uri

### DIFF
--- a/packages/react-oidc/README.md
+++ b/packages/react-oidc/README.md
@@ -182,6 +182,9 @@ const App = () => (
 render(<App />, document.getElementById('root'));
 ```
 
+> [!WARNING]
+> If you have both `redirect_uri` and `silent_redirect_uri` configured, their value must be different.
+
 ```javascript
 const configuration = {
   loadingComponent: ReactComponent, // you can inject your own loading component

--- a/packages/react-oidc/src/OidcProvider.tsx
+++ b/packages/react-oidc/src/OidcProvider.tsx
@@ -102,6 +102,12 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
   getFetch = null,
   location = null,
 }) => {
+  if (configuration && configuration.redirect_uri && configuration.silent_redirect_uri) {
+    if (configuration.redirect_uri === configuration.silent_redirect_uri) {
+      throw new Error('redirect_uri and silent_redirect_uri must be different');
+    }
+  }
+
   const getOidc = (configurationName = 'default') => {
     return OidcClient.getOrCreate(getFetch ?? getFetchDefault, location ?? new OidcLocation())(
       configuration,


### PR DESCRIPTION
## A picture tells a thousand words
Raise an exception in case `redirect_uri` is the same as `silent_redirect_uri`
<img width="1072" height="70" alt="image" src="https://github.com/user-attachments/assets/d66154fd-5c19-49c9-af6b-e9118c0dcb8e" />

