### PR TITLE
fix: do not handle all requests (alpha)

### DIFF
--- a/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
+++ b/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
@@ -107,6 +107,13 @@ async function generateDpopAsync(
  * On encapsule toute la logique dans un `respondWith((async () => { ... })())`.
  */
 const handleFetch = (event: FetchEvent): void => {
+  /**
+   * Exit early for requests that do not need to have an auth token attached.
+   */
+  const bypassedDestinations = ['image', 'font', 'media', 'document', 'iframe', 'script'];
+  if (bypassedDestinations.includes(event.request.destination)) {
+    return; // Don't call event.respondWith() - let browser handle naturally
+  }
   event.respondWith(
     (async (): Promise<Response> => {
       try {


### PR DESCRIPTION
## A picture tells a thousand words

fixes #1589

## Before this PR

all requests are handled via OIDC SW

## After this PR

A list of request types/destinations are not handled by the OIDC SW and thus show proper origin in Browser dev-tools and moreover do not require changes in CSP becuse the resources requested are not all treated as "connect-src"