### PR TITLE
Remove stale userInfo data on logout when using Service Worker

### DIFF
--- a/packages/oidc-client/src/initWorker.ts
+++ b/packages/oidc-client/src/initWorker.ts
@@ -247,6 +247,10 @@ export const initWorkerAsync = async (
   }
 
   const clearAsync = async status => {
+    // Ensure no stale userInfo data is kept in the browser storage when using SW.
+    // This completes the initial fix from https://github.com/AxaFrance/oidc-client/pull/1603
+    delete sessionStorage[`oidc.${configurationName}.userInfo`];
+    
     return sendMessageAsync(registration)({ type: 'clear', data: { status }, configurationName });
   };
 

--- a/packages/oidc-client/src/initWorker.ts
+++ b/packages/oidc-client/src/initWorker.ts
@@ -249,7 +249,7 @@ export const initWorkerAsync = async (
   const clearAsync = async status => {
     // Ensure no stale userInfo data is kept in the browser storage when using SW.
     // This completes the initial fix from https://github.com/AxaFrance/oidc-client/pull/1603
-    delete sessionStorage[`oidc.${configurationName}.userInfo`];
+    delete localStorage[`oidc.${configurationName}.userInfo`];
     
     return sendMessageAsync(registration)({ type: 'clear', data: { status }, configurationName });
   };

--- a/packages/oidc-client/src/initWorker.ts
+++ b/packages/oidc-client/src/initWorker.ts
@@ -250,7 +250,7 @@ export const initWorkerAsync = async (
     // Ensure no stale userInfo data is kept in the browser storage when using SW.
     // This completes the initial fix from https://github.com/AxaFrance/oidc-client/pull/1603
     delete localStorage[`oidc.${configurationName}.userInfo`];
-    
+
     return sendMessageAsync(registration)({ type: 'clear', data: { status }, configurationName });
   };
 


### PR DESCRIPTION
This is a follow-up of the fix I proposed in #1603. The fix only covered non-SW scenarios so the issue is still present as of today otherwise.

As a reminder, the issue is that when switching accounts, userInfo from the first account was stored and reloaded as-is, leading the various hooks to return stale data. Token behavior however works as expected.