### PR TITLE
fix(oidc): prevent storage poisoning on undefined setters (alpha)

### DIFF
--- a/packages/oidc-client/src/initSession.spec.ts
+++ b/packages/oidc-client/src/initSession.spec.ts
@@ -165,6 +165,71 @@ describe('initSession', () => {
     });
   });
 
+  describe('undefined/null guards (regression: #871 / #1257 / #1274)', () => {
+    let storage: Storage;
+    let session: ReturnType<typeof initSession>;
+
+    beforeEach(() => {
+      storage = makeStorage();
+      session = initSession(configName, storage);
+    });
+
+    it('setLoginParams(undefined) does not poison storage with the literal "undefined"', () => {
+      session.setLoginParams(undefined);
+      expect(storage[`oidc.login.${configName}`]).toBeUndefined();
+      expect(() => session.getLoginParams()).not.toThrow();
+      expect(session.getLoginParams()).toBeNull();
+    });
+
+    it('setLoginParams(null) clears storage rather than writing "null"', () => {
+      session.setLoginParams({ callbackPath: '/cb', extras: null, scope: 'openid' });
+      session.setLoginParams(null);
+      expect(storage[`oidc.login.${configName}`]).toBeUndefined();
+      expect(session.getLoginParams()).toBeNull();
+    });
+
+    it('getLoginParams tolerates a pre-existing poisoned "undefined" value', () => {
+      // simulate storage poisoned by an older version of the library
+      storage[`oidc.login.${configName}`] = 'undefined';
+      expect(() => session.getLoginParams()).not.toThrow();
+      expect(session.getLoginParams()).toBeNull();
+    });
+
+    it('getLoginParams tolerates a pre-existing poisoned "null" value', () => {
+      storage[`oidc.login.${configName}`] = 'null';
+      expect(() => session.getLoginParams()).not.toThrow();
+      expect(session.getLoginParams()).toBeNull();
+    });
+
+    it('initAsync tolerates a pre-existing poisoned "undefined" tokens entry', async () => {
+      storage[`oidc.${configName}`] = 'undefined';
+      await expect(session.initAsync()).resolves.toEqual({ tokens: null, status: null });
+    });
+
+    it('getTokens returns null for a pre-existing poisoned tokens entry', () => {
+      storage[`oidc.${configName}`] = 'undefined';
+      expect(() => session.getTokens()).not.toThrow();
+      expect(session.getTokens()).toBeNull();
+    });
+
+    it('setNonceAsync({nonce: undefined}) does not poison storage', async () => {
+      await session.setNonceAsync({ nonce: undefined as unknown as string });
+      expect(storage[`oidc.nonce.${configName}`]).toBeUndefined();
+      const { nonce } = await session.getNonceAsync();
+      expect(nonce).toBeUndefined();
+    });
+
+    it('setStateAsync(undefined) does not poison storage', async () => {
+      await session.setStateAsync(undefined as unknown as string);
+      expect(storage[`oidc.state.${configName}`]).toBeUndefined();
+    });
+
+    it('setCodeVerifierAsync(undefined) does not poison storage', async () => {
+      await session.setCodeVerifierAsync(undefined);
+      expect(storage[`oidc.code_verifier.${configName}`]).toBeUndefined();
+    });
+  });
+
   describe('two-tab isolation', () => {
     it('two sessions sharing tokenStorage but with independent loginStateStorages do not overwrite each other', async () => {
       const sharedTokenStorage = makeStorage();

--- a/packages/oidc-client/src/initSession.ts
+++ b/packages/oidc-client/src/initSession.ts
@@ -1,3 +1,39 @@
+// Guarded writes to storage. Assigning `undefined` or `null` through bracket
+// notation (or `setItem`) coerces the value to the literal strings
+// `"undefined"` / `"null"`, which then poison the next `JSON.parse` read.
+// See https://github.com/AxaFrance/oidc-client/issues/1257 (and #871, #1274).
+const writeJson = (storage: Storage, key: string, value: unknown) => {
+  if (value === undefined || value === null) {
+    delete storage[key];
+    return;
+  }
+  storage[key] = JSON.stringify(value);
+};
+
+const writeRaw = (storage: Storage, key: string, value: string | null | undefined) => {
+  if (value === undefined || value === null) {
+    delete storage[key];
+    return;
+  }
+  storage[key] = value;
+};
+
+const parseJsonOrNull = <T = unknown>(raw: unknown): T | null => {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  // Defence in depth against pre-existing poisoned values written by older
+  // versions of this library before the setter guards above were in place.
+  if (raw === 'undefined' || raw === 'null' || raw === '') {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+};
+
 export const initSession = (
   configurationName,
   storage = sessionStorage,
@@ -6,7 +42,7 @@ export const initSession = (
   const loginStorage = loginStateStorage ?? storage;
 
   const clearAsync = status => {
-    storage[`oidc.${configurationName}`] = JSON.stringify({ tokens: null, status });
+    writeJson(storage, `oidc.${configurationName}`, { tokens: null, status });
     delete storage[`oidc.${configurationName}.userInfo`];
     if (loginStateStorage && loginStateStorage !== storage) {
       delete loginStorage[`oidc.login.${configurationName}`];
@@ -18,20 +54,23 @@ export const initSession = (
   };
 
   const initAsync = async () => {
-    if (!storage[`oidc.${configurationName}`]) {
-      storage[`oidc.${configurationName}`] = JSON.stringify({ tokens: null, status: null });
+    const existing = parseJsonOrNull(storage[`oidc.${configurationName}`]) as {
+      tokens: any;
+      status: any;
+    } | null;
+    if (!existing) {
+      writeJson(storage, `oidc.${configurationName}`, { tokens: null, status: null });
       return { tokens: null, status: null };
     }
-    const data = JSON.parse(storage[`oidc.${configurationName}`]);
-    return Promise.resolve({ tokens: data.tokens, status: data.status });
+    return Promise.resolve({ tokens: existing.tokens, status: existing.status });
   };
 
   const setTokens = tokens => {
-    storage[`oidc.${configurationName}`] = JSON.stringify({ tokens });
+    writeJson(storage, `oidc.${configurationName}`, { tokens });
   };
 
   const setSessionStateAsync = async sessionState => {
-    storage[`oidc.session_state.${configurationName}`] = sessionState;
+    writeRaw(storage, `oidc.session_state.${configurationName}`, sessionState);
   };
 
   const getSessionStateAsync = async () => {
@@ -39,15 +78,15 @@ export const initSession = (
   };
 
   const setNonceAsync = nonce => {
-    loginStorage[`oidc.nonce.${configurationName}`] = nonce.nonce;
+    writeRaw(loginStorage, `oidc.nonce.${configurationName}`, nonce?.nonce);
   };
 
   const setDemonstratingProofOfPossessionJwkAsync = (jwk: JsonWebKey) => {
-    storage[`oidc.jwk.${configurationName}`] = JSON.stringify(jwk);
+    writeJson(storage, `oidc.jwk.${configurationName}`, jwk);
   };
 
   const getDemonstratingProofOfPossessionJwkAsync = () => {
-    return JSON.parse(storage[`oidc.jwk.${configurationName}`]);
+    return parseJsonOrNull<JsonWebKey>(storage[`oidc.jwk.${configurationName}`]);
   };
 
   const getNonceAsync = async () => {
@@ -56,7 +95,7 @@ export const initSession = (
   };
 
   const setDemonstratingProofOfPossessionNonce = async (dpopNonce: string) => {
-    storage[`oidc.dpop_nonce.${configurationName}`] = dpopNonce;
+    writeRaw(storage, `oidc.dpop_nonce.${configurationName}`, dpopNonce);
   };
 
   const getDemonstratingProofOfPossessionNonce = (): string => {
@@ -64,31 +103,38 @@ export const initSession = (
   };
 
   const getTokens = () => {
-    if (!storage[`oidc.${configurationName}`]) {
+    const parsed = parseJsonOrNull(storage[`oidc.${configurationName}`]) as {
+      tokens: any;
+    } | null;
+    if (!parsed) {
       return null;
     }
-    return JSON.stringify({ tokens: JSON.parse(storage[`oidc.${configurationName}`]).tokens });
+    return JSON.stringify({ tokens: parsed.tokens });
   };
 
   const getLoginParamsCache = {};
   const setLoginParams = data => {
+    if (data === undefined || data === null) {
+      delete getLoginParamsCache[configurationName];
+      delete loginStorage[`oidc.login.${configurationName}`];
+      return;
+    }
     getLoginParamsCache[configurationName] = data;
-    loginStorage[`oidc.login.${configurationName}`] = JSON.stringify(data);
+    writeJson(loginStorage, `oidc.login.${configurationName}`, data);
   };
   const getLoginParams = () => {
-    const dataString = loginStorage[`oidc.login.${configurationName}`];
-
-    if (!dataString) {
+    if (getLoginParamsCache[configurationName]) {
+      return getLoginParamsCache[configurationName];
+    }
+    const parsed = parseJsonOrNull(loginStorage[`oidc.login.${configurationName}`]);
+    if (parsed === null) {
       console.warn(
         `storage[oidc.login.${configurationName}] is empty, you should have an bad OIDC or code configuration somewhere.`,
       );
       return null;
     }
-
-    if (!getLoginParamsCache[configurationName]) {
-      getLoginParamsCache[configurationName] = JSON.parse(dataString);
-    }
-    return getLoginParamsCache[configurationName];
+    getLoginParamsCache[configurationName] = parsed;
+    return parsed;
   };
 
   const getStateAsync = async () => {
@@ -96,7 +142,7 @@ export const initSession = (
   };
 
   const setStateAsync = async (state: string) => {
-    loginStorage[`oidc.state.${configurationName}`] = state;
+    writeRaw(loginStorage, `oidc.state.${configurationName}`, state);
   };
 
   const getCodeVerifierAsync = async () => {
@@ -104,7 +150,7 @@ export const initSession = (
   };
 
   const setCodeVerifierAsync = async codeVerifier => {
-    loginStorage[`oidc.code_verifier.${configurationName}`] = codeVerifier;
+    writeRaw(loginStorage, `oidc.code_verifier.${configurationName}`, codeVerifier);
   };
 
   return {

--- a/packages/oidc-client/src/initWorker.ts
+++ b/packages/oidc-client/src/initWorker.ts
@@ -541,14 +541,34 @@ export const initWorkerAsync = async (
 
   const getLoginParamsCache = {};
   const setLoginParams = data => {
+    if (data === undefined || data === null) {
+      delete getLoginParamsCache[configurationName];
+      delete localStorage[`oidc.login.${configurationName}`];
+      return;
+    }
     getLoginParamsCache[configurationName] = data;
     localStorage[`oidc.login.${configurationName}`] = JSON.stringify(data);
   };
 
   const getLoginParams = () => {
+    if (getLoginParamsCache[configurationName]) {
+      return getLoginParamsCache[configurationName];
+    }
     const dataString = localStorage[`oidc.login.${configurationName}`];
-    if (!getLoginParamsCache[configurationName]) {
+    // Guard against the literal strings "undefined" / "null" written by older
+    // builds of this library through bracket-notation assignment.
+    if (
+      typeof dataString !== 'string' ||
+      dataString === '' ||
+      dataString === 'undefined' ||
+      dataString === 'null'
+    ) {
+      return null;
+    }
+    try {
       getLoginParamsCache[configurationName] = JSON.parse(dataString);
+    } catch {
+      return null;
     }
     return getLoginParamsCache[configurationName];
   };


### PR DESCRIPTION
## A picture tells a thousand words

```js
// in a browser console:
localStorage['oidc.login.default'] = undefined;
localStorage.getItem('oidc.login.default');
// → "undefined"   (the literal string)

JSON.parse(localStorage.getItem('oidc.login.default'));
// → Uncaught SyntaxError: "undefined" is not valid JSON
```

## Before this PR

Every setter in `initSession.ts` (and the SW fallback path in `initWorker.ts`) writes through bracket notation:

```ts
loginStorage[`oidc.login.${configurationName}`] = JSON.stringify(data);
```

When `data === undefined`, `JSON.stringify(undefined)` returns the JS value `undefined`. The Web Storage spec then coerces that to the literal string `\"undefined\"` on bracket-notation assignment. The next read of `getLoginParams` calls `JSON.parse(\"undefined\")` → throws.

We have observed this throw **3593 times across 391 users in 6 months** in production logs.

Prior reports/PRs for the same symptom:
- #871 (2022-09) — closed, no fix
- #1257 (2024-01) — closed after PR #1258 added a getter guard
- #1274 (2024-02) — closed as duplicate

PR #1258 added `if (!dataString)` in `getLoginParams`, but `\"undefined\"` is a *truthy* string so that guard misses the poisoning case. The setter side has never been addressed, and the same pattern exists for other keys (`oidc.${name}` tokens, `oidc.jwk.${name}`, `oidc.nonce.${name}`, `oidc.state.${name}`, `oidc.code_verifier.${name}`, `oidc.session_state.${name}`).

## After this PR

1. **Every setter is guarded.** If the input is `undefined`/`null`, the key is deleted instead of being assigned a coerced string. This covers `setLoginParams`, `setTokens`, `setNonceAsync`, `setStateAsync`, `setCodeVerifierAsync`, `setSessionStateAsync`, and both DPoP setters.

2. **Defence in depth on the read side.** A new `parseJsonOrNull` helper treats the literal strings `\"undefined\"`, `\"null\"`, and `\"\"` as missing, so storage already poisoned by older versions of the library self-heals on the next read (`initAsync`, `getTokens`, `getLoginParams`, `getDemonstratingProofOfPossessionJwkAsync`).

3. **SW fallback path in `initWorker.ts`** gets the same treatment for `setLoginParams`/`getLoginParams` (it has its own copy of this code outside `initSession`).

4. **Regression tests** in `initSession.spec.ts` cover both new poisoning attempts (calling setters with `undefined`/`null`) and recovery from pre-existing poisoned storage entries written by older builds.

## Verification recipe

1. `localStorage['oidc.login.default'] = undefined` (in DevTools).
2. `localStorage.getItem('oidc.login.default')` → returns the string `\"undefined\"`.
3. Trigger any silent refresh / login callback path → reproducible throw on `main`.
4. With this PR applied, step 1 deletes the key (or, if storage is pre-poisoned, the next read self-heals).

## Test plan

- [x] `pnpm exec vitest run --root .` in `packages/oidc-client` → 63 / 63 pass (9 new).
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec prettier --check` and `pnpm exec eslint` clean.

## Commit tag

Tagged `(alpha)` per `CONTRIBUTING.md` — happy to retag to `(beta)` or `(release)` if you'd prefer given the production impact (the fix is intentionally narrow and additive-only, no API or behaviour change for any non-poisoned input).