### PR TITLE
Auto fix for issue #1683: navigation requests to new window/tab bypass token injection since 7.27.4

### DIFF
--- a/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
+++ b/packages/oidc-client-service-worker/src/OidcServiceWorker.ts
@@ -11,6 +11,7 @@ import {
   hideTokens,
   normalizeUrl,
   serializeHeaders,
+  shouldBypassDestination,
   sleep,
   waitForValidTokens,
 } from './utils';
@@ -109,8 +110,7 @@ const handleFetch = (event: FetchEvent): void => {
   /**
    * Exit early for requests that do not need to have an auth token attached.
    */
-  const bypassedDestinations = ['image', 'font', 'media', 'document', 'iframe', 'script'];
-  if (bypassedDestinations.includes(event.request.destination)) {
+  if (shouldBypassDestination(event.request.destination, event.request.mode)) {
     return; // Don't call event.respondWith() - let browser handle naturally
   }
 

--- a/packages/oidc-client-service-worker/src/utils/__tests__/destinations.spec.ts
+++ b/packages/oidc-client-service-worker/src/utils/__tests__/destinations.spec.ts
@@ -8,7 +8,7 @@ describe('shouldBypassDestination', () => {
   describe('non-navigate requests with bypassed destinations', () => {
     it.each(bypassedDestinations)(
       'should bypass "%s" destination when mode is not navigate',
-      (destination) => {
+      destination => {
         expect(shouldBypassDestination(destination, 'cors')).toBe(true);
         expect(shouldBypassDestination(destination, 'same-origin')).toBe(true);
         expect(shouldBypassDestination(destination, 'no-cors')).toBe(true);
@@ -23,7 +23,7 @@ describe('shouldBypassDestination', () => {
 
     it.each(bypassedDestinations)(
       'should not bypass "%s" destination when mode is "navigate"',
-      (destination) => {
+      destination => {
         expect(shouldBypassDestination(destination, 'navigate')).toBe(false);
       },
     );

--- a/packages/oidc-client-service-worker/src/utils/__tests__/destinations.spec.ts
+++ b/packages/oidc-client-service-worker/src/utils/__tests__/destinations.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldBypassDestination } from '../destinations';
+
+describe('shouldBypassDestination', () => {
+  const bypassedDestinations = ['image', 'font', 'media', 'document', 'iframe', 'script'];
+
+  describe('non-navigate requests with bypassed destinations', () => {
+    it.each(bypassedDestinations)(
+      'should bypass "%s" destination when mode is not navigate',
+      (destination) => {
+        expect(shouldBypassDestination(destination, 'cors')).toBe(true);
+        expect(shouldBypassDestination(destination, 'same-origin')).toBe(true);
+        expect(shouldBypassDestination(destination, 'no-cors')).toBe(true);
+      },
+    );
+  });
+
+  describe('navigate requests should NOT be bypassed (issue #1683)', () => {
+    it('should not bypass "document" destination when mode is "navigate"', () => {
+      expect(shouldBypassDestination('document', 'navigate')).toBe(false);
+    });
+
+    it.each(bypassedDestinations)(
+      'should not bypass "%s" destination when mode is "navigate"',
+      (destination) => {
+        expect(shouldBypassDestination(destination, 'navigate')).toBe(false);
+      },
+    );
+  });
+
+  describe('non-bypassed destinations', () => {
+    it('should not bypass empty destination', () => {
+      expect(shouldBypassDestination('', 'cors')).toBe(false);
+    });
+
+    it('should not bypass "worker" destination', () => {
+      expect(shouldBypassDestination('worker', 'cors')).toBe(false);
+    });
+
+    it('should not bypass unknown destinations', () => {
+      expect(shouldBypassDestination('audio', 'cors')).toBe(false);
+      expect(shouldBypassDestination('fetch', 'cors')).toBe(false);
+    });
+  });
+});

--- a/packages/oidc-client-service-worker/src/utils/destinations.ts
+++ b/packages/oidc-client-service-worker/src/utils/destinations.ts
@@ -1,0 +1,10 @@
+const bypassedDestinations = ['image', 'font', 'media', 'document', 'iframe', 'script'];
+
+/**
+ * Determines whether a fetch request should bypass the service worker's token injection.
+ * Navigation requests (mode === "navigate") are never bypassed, even if their destination
+ * is in the bypassed list, so that the access token can be injected for new-tab navigations.
+ */
+export const shouldBypassDestination = (destination: string, mode: string): boolean => {
+  return bypassedDestinations.includes(destination) && mode !== 'navigate';
+};

--- a/packages/oidc-client-service-worker/src/utils/index.ts
+++ b/packages/oidc-client-service-worker/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './destinations';
 export * from './domains';
 export * from './normalizeUrl';
 export * from './serializeHeaders';


### PR DESCRIPTION
This pull request was created automatically for issue #1683 (https://github.com/AxaFrance/oidc-client/issues/1683).
Summary of the need: Navigation requests opened in a new tab (with request mode "navigate" and destination "document") no longer receive injected access tokens since v7.27.4, causing 401 errors when accessing protected resources like PDFs. The regression stems from a new destination-based early-return in the service worker fetch handler that skips such requests. The reporter proposes either exempting `mode="navigate"` from this bypass or making the bypass list configurable. This would restore prior behavior where navigation requests were correctly authorized under the `setAccessTokenToNavigateRequests` option.
Implementation plan and notes from Copilot Ask: 1. Open `packages/oidc-client-service-worker/src/OidcServiceWorker.ts`.
2. Locate the `handleFetch` function and the `bypassedDestinations` logic near the top of the function.
3. Replace the current early-return condition:
   - From: `if (bypassedDestinations.includes(event.request.destination)) { return; }`
   - To: a conditional that only returns when the destination is in `bypassedDestinations` **and** the request mode is not `"navigate"`.
4. Ensure the rest of the logic that handles navigation requests (including honoring `setAccessTokenToNavigateRequests`) remains unchanged.
5. Add or update tests (unit/integration, or a manual test scenario) to verify that:
   - Navigation requests (`mode: "navigate"`, `destination: "document"`) receive the access token when configured, including when opening a protected URL in a new tab.
   - Non-navigation resource requests (images, fonts, media, scripts, iframes) are still bypassed and not modified by the service worker.
6. Update changelog/release notes to mention the regression fix for navigation requests in the service worker token injection logic.
Additional description: Fix service worker regression by ensuring `handleFetch` does not bypass `mode: "navigate"` requests when `destination` is `"document"`, restoring access token injection for navigation requests such as protected documents opened in a new tab.
This operation was performed by an AI via GnOuGo, the cute little bear who just wants to be adopted: https://github.com/GnouGo/GnouGo
