### PR TITLE
Auto fix for issue #1682: CallbackManager: no observable signal that post-callback navigation has committed (Safari edge case)

### DIFF
--- a/packages/oidc-client/src/events.ts
+++ b/packages/oidc-client/src/events.ts
@@ -10,6 +10,8 @@ export const eventNames = {
   loginCallbackAsync_begin: 'loginCallbackAsync_begin',
   loginCallbackAsync_end: 'loginCallbackAsync_end',
   loginCallbackAsync_error: 'loginCallbackAsync_error',
+  loginCallbackAsync_navigated: 'loginCallbackAsync_navigated',
+  loginCallbackAsync_navigation_error: 'loginCallbackAsync_navigation_error',
   refreshTokensAsync_begin: 'refreshTokensAsync_begin',
   refreshTokensAsync: 'refreshTokensAsync',
   refreshTokensAsync_end: 'refreshTokensAsync_end',

--- a/packages/react-oidc/src/OidcProvider.tsx
+++ b/packages/react-oidc/src/OidcProvider.tsx
@@ -39,6 +39,7 @@ export type OidcProviderProps = {
   onLogoutFromAnotherTab?: () => void;
   onLogoutFromSameTab?: () => void;
   withCustomHistory?: () => CustomHistory;
+  navigateAfterCallback?: (callbackPath: string) => Promise<void>;
   onEvent?: (configuration: string, name: string, data: any) => void;
   getFetch?: () => Fetch;
   location?: ILOidcLocation;
@@ -98,6 +99,7 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
   onLogoutFromAnotherTab = null,
   onLogoutFromSameTab = null,
   withCustomHistory = null,
+  navigateAfterCallback = null,
   onEvent = null,
   getFetch = null,
   location = null,
@@ -250,6 +252,7 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
             authenticatingComponent={authenticatingComponent}
             configurationName={configurationName}
             withCustomHistory={withCustomHistory}
+            navigateAfterCallback={navigateAfterCallback}
             location={location ?? new OidcLocation()}
           >
             <OidcSession loadingComponent={LoadingComponent} configurationName={configurationName}>

--- a/packages/react-oidc/src/core/default-component/Callback.component.spec.tsx
+++ b/packages/react-oidc/src/core/default-component/Callback.component.spec.tsx
@@ -1,0 +1,268 @@
+import { act, render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CallbackManager, {
+  CallBackSuccess,
+  verifyNavigationCommitted,
+} from './Callback.component';
+
+vi.mock('@axa-fr/oidc-client', () => ({
+  OidcClient: {
+    get: vi.fn(),
+    eventNames: {
+      loginCallbackAsync_navigated: 'loginCallbackAsync_navigated',
+      loginCallbackAsync_navigation_error: 'loginCallbackAsync_navigation_error',
+    },
+  },
+}));
+
+vi.mock('../routes/withRouter.js', () => ({
+  getCustomHistory: vi.fn(),
+}));
+
+import { OidcClient } from '@axa-fr/oidc-client';
+
+import { getCustomHistory } from '../routes/withRouter.js';
+
+describe('verifyNavigationCommitted', () => {
+  it('should return true when current path matches target path', () => {
+    const windowMock = { location: { pathname: '/dashboard' } } as Window;
+    expect(verifyNavigationCommitted('/dashboard', windowMock)).toBe(true);
+  });
+
+  it('should return false when current path does not match target path', () => {
+    const windowMock = { location: { pathname: '/callback' } } as Window;
+    expect(verifyNavigationCommitted('/dashboard', windowMock)).toBe(false);
+  });
+
+  it('should return true when target path is root', () => {
+    const windowMock = { location: { pathname: '/anything' } } as Window;
+    expect(verifyNavigationCommitted('/', windowMock)).toBe(true);
+  });
+});
+
+describe('CallBackSuccess', () => {
+  it('renders the success message', () => {
+    const { getByText } = render(<CallBackSuccess />);
+    expect(getByText('Authentication complete')).toBeTruthy();
+    expect(getByText('You will be redirected to your application.')).toBeTruthy();
+  });
+});
+
+describe('CallbackManager', () => {
+  let mockPublishEvent: ReturnType<typeof vi.fn>;
+  let mockLoginCallbackAsync: ReturnType<typeof vi.fn>;
+  let mockReplaceState: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockPublishEvent = vi.fn();
+    mockLoginCallbackAsync = vi.fn();
+    mockReplaceState = vi.fn();
+
+    (OidcClient.get as ReturnType<typeof vi.fn>).mockReturnValue({
+      loginCallbackAsync: mockLoginCallbackAsync,
+      publishEvent: mockPublishEvent,
+    });
+
+    (getCustomHistory as ReturnType<typeof vi.fn>).mockReturnValue({
+      replaceState: mockReplaceState,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should use navigateAfterCallback when provided and emit navigated event on success', async () => {
+    mockLoginCallbackAsync.mockResolvedValue({ callbackPath: '/dashboard' });
+    const navigateAfterCallback = vi.fn().mockResolvedValue(undefined);
+
+    await act(async () => {
+      render(
+        <CallbackManager
+          configurationName="default"
+          navigateAfterCallback={navigateAfterCallback}
+        />,
+      );
+    });
+
+    expect(navigateAfterCallback).toHaveBeenCalledWith('/dashboard');
+    expect(mockPublishEvent).toHaveBeenCalledWith(
+      'loginCallbackAsync_navigated',
+      { configurationName: 'default', callbackPath: '/dashboard' },
+    );
+  });
+
+  it('should emit navigation_error event when navigateAfterCallback rejects', async () => {
+    mockLoginCallbackAsync.mockResolvedValue({ callbackPath: '/dashboard' });
+    const navError = new Error('Navigation failed');
+    const navigateAfterCallback = vi.fn().mockRejectedValue(navError);
+
+    await act(async () => {
+      render(
+        <CallbackManager
+          configurationName="default"
+          navigateAfterCallback={navigateAfterCallback}
+        />,
+      );
+    });
+
+    expect(mockPublishEvent).toHaveBeenCalledWith(
+      'loginCallbackAsync_navigation_error',
+      { configurationName: 'default', callbackPath: '/dashboard', error: navError },
+    );
+  });
+
+  it('should render error component when navigateAfterCallback fails', async () => {
+    mockLoginCallbackAsync.mockResolvedValue({ callbackPath: '/dashboard' });
+    const navigateAfterCallback = vi.fn().mockRejectedValue(new Error('fail'));
+
+    const ErrorComponent = () => <div>Error occurred</div>;
+
+    let container;
+    await act(async () => {
+      const result = render(
+        <CallbackManager
+          configurationName="default"
+          navigateAfterCallback={navigateAfterCallback}
+          callBackError={ErrorComponent}
+        />,
+      );
+      container = result.container;
+    });
+
+    expect(container.textContent).toContain('Error occurred');
+  });
+
+  it('should use default history navigation when navigateAfterCallback is not provided', async () => {
+    vi.useRealTimers();
+    mockLoginCallbackAsync.mockResolvedValue({ callbackPath: '/dashboard' });
+
+    // Mock window.location to simulate successful navigation
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/dashboard' },
+      writable: true,
+    });
+
+    await act(async () => {
+      render(
+        <CallbackManager
+          configurationName="default"
+        />,
+      );
+      // Wait for the verification delay to pass
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+
+    expect(mockReplaceState).toHaveBeenCalledWith('/dashboard');
+
+    await waitFor(() => {
+      expect(mockPublishEvent).toHaveBeenCalledWith(
+        'loginCallbackAsync_navigated',
+        { configurationName: 'default', callbackPath: '/dashboard' },
+      );
+    });
+  });
+
+  it('should emit navigation_error when default navigation does not commit', async () => {
+    vi.useRealTimers();
+    mockLoginCallbackAsync.mockResolvedValue({ callbackPath: '/dashboard' });
+
+    // Mock window.location to simulate failed navigation
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/callback' },
+      writable: true,
+    });
+
+    await act(async () => {
+      render(
+        <CallbackManager
+          configurationName="default"
+        />,
+      );
+      // Wait for the verification delay to pass
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+
+    await waitFor(() => {
+      expect(mockPublishEvent).toHaveBeenCalledWith(
+        'loginCallbackAsync_navigation_error',
+        expect.objectContaining({
+          configurationName: 'default',
+          callbackPath: '/dashboard',
+        }),
+      );
+    });
+  });
+
+  it('should use "/" as fallback when callbackPath is empty', async () => {
+    mockLoginCallbackAsync.mockResolvedValue({ callbackPath: '' });
+    const navigateAfterCallback = vi.fn().mockResolvedValue(undefined);
+
+    await act(async () => {
+      render(
+        <CallbackManager
+          configurationName="default"
+          navigateAfterCallback={navigateAfterCallback}
+        />,
+      );
+    });
+
+    expect(navigateAfterCallback).toHaveBeenCalledWith('/');
+  });
+
+  it('should use withCustomHistory when provided and no navigateAfterCallback', async () => {
+    mockLoginCallbackAsync.mockResolvedValue({ callbackPath: '/profile' });
+    const customReplaceState = vi.fn();
+    const withCustomHistory = vi.fn().mockReturnValue({ replaceState: customReplaceState });
+
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/' },
+      writable: true,
+    });
+
+    await act(async () => {
+      render(
+        <CallbackManager
+          configurationName="default"
+          withCustomHistory={withCustomHistory}
+        />,
+      );
+    });
+
+    expect(withCustomHistory).toHaveBeenCalled();
+    expect(customReplaceState).toHaveBeenCalledWith('/profile');
+  });
+
+  it('should set error state when loginCallbackAsync throws', async () => {
+    mockLoginCallbackAsync.mockRejectedValue(new Error('login error'));
+
+    const ErrorComponent = () => <div>Login Error</div>;
+
+    let container;
+    await act(async () => {
+      const result = render(
+        <CallbackManager
+          configurationName="default"
+          callBackError={ErrorComponent}
+        />,
+      );
+      container = result.container;
+    });
+
+    expect(container.textContent).toContain('Login Error');
+  });
+
+  it('should render success component by default', () => {
+    mockLoginCallbackAsync.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const { getByText } = render(
+      <CallbackManager configurationName="default" />,
+    );
+
+    expect(getByText('Authentication complete')).toBeTruthy();
+  });
+});

--- a/packages/react-oidc/src/core/default-component/Callback.component.spec.tsx
+++ b/packages/react-oidc/src/core/default-component/Callback.component.spec.tsx
@@ -2,10 +2,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import CallbackManager, {
-  CallBackSuccess,
-  verifyNavigationCommitted,
-} from './Callback.component';
+import CallbackManager, { CallBackSuccess, verifyNavigationCommitted } from './Callback.component';
 
 vi.mock('@axa-fr/oidc-client', () => ({
   OidcClient: {
@@ -90,10 +87,10 @@ describe('CallbackManager', () => {
     });
 
     expect(navigateAfterCallback).toHaveBeenCalledWith('/dashboard');
-    expect(mockPublishEvent).toHaveBeenCalledWith(
-      'loginCallbackAsync_navigated',
-      { configurationName: 'default', callbackPath: '/dashboard' },
-    );
+    expect(mockPublishEvent).toHaveBeenCalledWith('loginCallbackAsync_navigated', {
+      configurationName: 'default',
+      callbackPath: '/dashboard',
+    });
   });
 
   it('should emit navigation_error event when navigateAfterCallback rejects', async () => {
@@ -110,10 +107,11 @@ describe('CallbackManager', () => {
       );
     });
 
-    expect(mockPublishEvent).toHaveBeenCalledWith(
-      'loginCallbackAsync_navigation_error',
-      { configurationName: 'default', callbackPath: '/dashboard', error: navError },
-    );
+    expect(mockPublishEvent).toHaveBeenCalledWith('loginCallbackAsync_navigation_error', {
+      configurationName: 'default',
+      callbackPath: '/dashboard',
+      error: navError,
+    });
   });
 
   it('should render error component when navigateAfterCallback fails', async () => {
@@ -148,22 +146,18 @@ describe('CallbackManager', () => {
     });
 
     await act(async () => {
-      render(
-        <CallbackManager
-          configurationName="default"
-        />,
-      );
+      render(<CallbackManager configurationName="default" />);
       // Wait for the verification delay to pass
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      await new Promise(resolve => setTimeout(resolve, 300));
     });
 
     expect(mockReplaceState).toHaveBeenCalledWith('/dashboard');
 
     await waitFor(() => {
-      expect(mockPublishEvent).toHaveBeenCalledWith(
-        'loginCallbackAsync_navigated',
-        { configurationName: 'default', callbackPath: '/dashboard' },
-      );
+      expect(mockPublishEvent).toHaveBeenCalledWith('loginCallbackAsync_navigated', {
+        configurationName: 'default',
+        callbackPath: '/dashboard',
+      });
     });
   });
 
@@ -178,13 +172,9 @@ describe('CallbackManager', () => {
     });
 
     await act(async () => {
-      render(
-        <CallbackManager
-          configurationName="default"
-        />,
-      );
+      render(<CallbackManager configurationName="default" />);
       // Wait for the verification delay to pass
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      await new Promise(resolve => setTimeout(resolve, 300));
     });
 
     await waitFor(() => {
@@ -225,12 +215,7 @@ describe('CallbackManager', () => {
     });
 
     await act(async () => {
-      render(
-        <CallbackManager
-          configurationName="default"
-          withCustomHistory={withCustomHistory}
-        />,
-      );
+      render(<CallbackManager configurationName="default" withCustomHistory={withCustomHistory} />);
     });
 
     expect(withCustomHistory).toHaveBeenCalled();
@@ -245,10 +230,7 @@ describe('CallbackManager', () => {
     let container;
     await act(async () => {
       const result = render(
-        <CallbackManager
-          configurationName="default"
-          callBackError={ErrorComponent}
-        />,
+        <CallbackManager configurationName="default" callBackError={ErrorComponent} />,
       );
       container = result.container;
     });
@@ -259,9 +241,7 @@ describe('CallbackManager', () => {
   it('should render success component by default', () => {
     mockLoginCallbackAsync.mockReturnValue(new Promise(() => {})); // never resolves
 
-    const { getByText } = render(
-      <CallbackManager configurationName="default" />,
-    );
+    const { getByText } = render(<CallbackManager configurationName="default" />);
 
     expect(getByText('Authentication complete')).toBeTruthy();
   });

--- a/packages/react-oidc/src/core/default-component/Callback.component.tsx
+++ b/packages/react-oidc/src/core/default-component/Callback.component.tsx
@@ -43,15 +43,16 @@ const CallbackManager: ComponentType<any> = ({
         if (navigateAfterCallback) {
           try {
             await navigateAfterCallback(targetPath);
-            oidcClient.publishEvent(
-              OidcClient.eventNames.loginCallbackAsync_navigated,
-              { configurationName, callbackPath: targetPath },
-            );
+            oidcClient.publishEvent(OidcClient.eventNames.loginCallbackAsync_navigated, {
+              configurationName,
+              callbackPath: targetPath,
+            });
           } catch (navigationError) {
-            oidcClient.publishEvent(
-              OidcClient.eventNames.loginCallbackAsync_navigation_error,
-              { configurationName, callbackPath: targetPath, error: navigationError },
-            );
+            oidcClient.publishEvent(OidcClient.eventNames.loginCallbackAsync_navigation_error, {
+              configurationName,
+              callbackPath: targetPath,
+              error: navigationError,
+            });
             if (isMounted) {
               console.warn(navigationError);
               setIsError(true);
@@ -61,7 +62,7 @@ const CallbackManager: ComponentType<any> = ({
           const history = withCustomHistory ? withCustomHistory() : getCustomHistory();
           history.replaceState(targetPath);
 
-          await new Promise<void>((resolve) => {
+          await new Promise<void>(resolve => {
             setTimeout(() => {
               resolve();
             }, NAVIGATION_VERIFICATION_DELAY_MS);
@@ -70,21 +71,18 @@ const CallbackManager: ComponentType<any> = ({
           if (isMounted) {
             const committed = verifyNavigationCommitted(targetPath);
             if (committed) {
-              oidcClient.publishEvent(
-                OidcClient.eventNames.loginCallbackAsync_navigated,
-                { configurationName, callbackPath: targetPath },
-              );
+              oidcClient.publishEvent(OidcClient.eventNames.loginCallbackAsync_navigated, {
+                configurationName,
+                callbackPath: targetPath,
+              });
             } else {
-              oidcClient.publishEvent(
-                OidcClient.eventNames.loginCallbackAsync_navigation_error,
-                {
-                  configurationName,
-                  callbackPath: targetPath,
-                  error: new Error(
-                    `Navigation did not commit: expected "${targetPath}" but found "${window.location.pathname}"`,
-                  ),
-                },
-              );
+              oidcClient.publishEvent(OidcClient.eventNames.loginCallbackAsync_navigation_error, {
+                configurationName,
+                callbackPath: targetPath,
+                error: new Error(
+                  `Navigation did not commit: expected "${targetPath}" but found "${window.location.pathname}"`,
+                ),
+              });
               setIsError(true);
             }
           }

--- a/packages/react-oidc/src/core/default-component/Callback.component.tsx
+++ b/packages/react-oidc/src/core/default-component/Callback.component.tsx
@@ -13,11 +13,22 @@ export const CallBackSuccess: ComponentType<any> = () => (
   </div>
 );
 
+const NAVIGATION_VERIFICATION_DELAY_MS = 200;
+
+export const verifyNavigationCommitted = (
+  targetPath: string,
+  windowInternal: Window = window,
+): boolean => {
+  const currentPath = windowInternal.location.pathname;
+  return currentPath === targetPath || targetPath === '/';
+};
+
 const CallbackManager: ComponentType<any> = ({
   callBackError,
   callBackSuccess,
   configurationName,
   withCustomHistory,
+  navigateAfterCallback,
 }) => {
   const [isError, setIsError] = useState(false);
   useEffect(() => {
@@ -25,9 +36,59 @@ const CallbackManager: ComponentType<any> = ({
     const playCallbackAsync = async () => {
       const getOidc = OidcClient.get;
       try {
-        const { callbackPath } = await getOidc(configurationName).loginCallbackAsync();
-        const history = withCustomHistory ? withCustomHistory() : getCustomHistory();
-        history.replaceState(callbackPath || '/');
+        const oidcClient = getOidc(configurationName);
+        const { callbackPath } = await oidcClient.loginCallbackAsync();
+        const targetPath = callbackPath || '/';
+
+        if (navigateAfterCallback) {
+          try {
+            await navigateAfterCallback(targetPath);
+            oidcClient.publishEvent(
+              OidcClient.eventNames.loginCallbackAsync_navigated,
+              { configurationName, callbackPath: targetPath },
+            );
+          } catch (navigationError) {
+            oidcClient.publishEvent(
+              OidcClient.eventNames.loginCallbackAsync_navigation_error,
+              { configurationName, callbackPath: targetPath, error: navigationError },
+            );
+            if (isMounted) {
+              console.warn(navigationError);
+              setIsError(true);
+            }
+          }
+        } else {
+          const history = withCustomHistory ? withCustomHistory() : getCustomHistory();
+          history.replaceState(targetPath);
+
+          await new Promise<void>((resolve) => {
+            setTimeout(() => {
+              resolve();
+            }, NAVIGATION_VERIFICATION_DELAY_MS);
+          });
+
+          if (isMounted) {
+            const committed = verifyNavigationCommitted(targetPath);
+            if (committed) {
+              oidcClient.publishEvent(
+                OidcClient.eventNames.loginCallbackAsync_navigated,
+                { configurationName, callbackPath: targetPath },
+              );
+            } else {
+              oidcClient.publishEvent(
+                OidcClient.eventNames.loginCallbackAsync_navigation_error,
+                {
+                  configurationName,
+                  callbackPath: targetPath,
+                  error: new Error(
+                    `Navigation did not commit: expected "${targetPath}" but found "${window.location.pathname}"`,
+                  ),
+                },
+              );
+              setIsError(true);
+            }
+          }
+        }
       } catch (error) {
         if (isMounted) {
           console.warn(error);

--- a/packages/react-oidc/src/core/routes/OidcRoutes.tsx
+++ b/packages/react-oidc/src/core/routes/OidcRoutes.tsx
@@ -15,6 +15,7 @@ type OidcRoutesProps = {
   silent_redirect_uri?: string;
   silent_login_uri?: string;
   withCustomHistory?: () => CustomHistory;
+  navigateAfterCallback?: (callbackPath: string) => Promise<void>;
   location: ILOidcLocation;
 };
 
@@ -27,6 +28,7 @@ const OidcRoutes: FC<PropsWithChildren<OidcRoutesProps>> = ({
   children,
   configurationName,
   withCustomHistory = null,
+  navigateAfterCallback = null,
 }) => {
   // This exist because in next.js window outside useEffect is null
   const pathname = window ? getPath(window.location.href) : '';
@@ -62,6 +64,7 @@ const OidcRoutes: FC<PropsWithChildren<OidcRoutesProps>> = ({
           callBackSuccess={callbackSuccessComponent}
           configurationName={configurationName}
           withCustomHistory={withCustomHistory}
+          navigateAfterCallback={navigateAfterCallback}
         />
       );
     default:

--- a/packages/react-oidc/src/index.ts
+++ b/packages/react-oidc/src/index.ts
@@ -1,5 +1,6 @@
 export { useOidcFetch, withOidcFetch } from './FetchToken.js';
 export { OidcProvider } from './OidcProvider.js';
+export type { OidcProviderProps } from './OidcProvider.js';
 export { OidcSecure, withOidcSecure } from './OidcSecure.js';
 export { useOidc, useOidcAccessToken, useOidcIdToken } from './ReactOidc.js';
 export { OidcUserStatus, useOidcUser } from './User.js';

--- a/packages/react-oidc/src/index.ts
+++ b/packages/react-oidc/src/index.ts
@@ -1,6 +1,6 @@
 export { useOidcFetch, withOidcFetch } from './FetchToken.js';
-export { OidcProvider } from './OidcProvider.js';
 export type { OidcProviderProps } from './OidcProvider.js';
+export { OidcProvider } from './OidcProvider.js';
 export { OidcSecure, withOidcSecure } from './OidcSecure.js';
 export { useOidc, useOidcAccessToken, useOidcIdToken } from './ReactOidc.js';
 export { OidcUserStatus, useOidcUser } from './User.js';


### PR DESCRIPTION
This pull request was created automatically for issue #1682 (https://github.com/AxaFrance/oidc-client/issues/1682).
Summary of the need: After `loginCallbackAsync` completes, the React callback component calls `history.replaceState` and immediately shows a success message, but there is no way for consumers to know whether the navigation actually committed. On iOS Safari, this sometimes results in users remaining stuck on the callback URL with a "you will be redirected" message that never resolves. The reporter suggests adding an observable event or promise that confirms navigation success, or allowing consumers to plug in an async `navigateAfterCallback` function that the library awaits and can report errors from. This would enable robust recovery when Safari or the router fails to perform the final navigation.
Implementation plan and notes from Copilot Ask: High-level implementation plan:

1. **Extend public API for navigation control**
   - Add an optional `navigateAfterCallback?: (callbackPath: string) => Promise<void>` prop to the relevant public entry point, likely `OidcProviderProps` (and any other component that directly renders the callback route).
   - Thread this prop through intermediate components (`OidcRoutes`, callback-related components) down to the core `Callback.component.tsx` (or equivalent callback manager).

2. **Add new navigation-related events**
   - In the shared event definitions (e.g., `events.ts` in the core package), add two new event names:
     - `loginCallbackAsync_navigated` (or a similar, clear name like `callback_navigation_committed`).
     - `loginCallbackAsync_navigation_error`.
   - Ensure these events can be emitted via the existing event publishing utilities and consumed via the existing `onEvent` / subscription mechanisms.

3. **Update callback component logic**
   - In `packages/react-oidc/src/core/default-component/Callback.component.tsx` (or the current callback manager):
     - After `loginCallbackAsync()` resolves and returns `{ callbackPath }`:
       - If `navigateAfterCallback` is provided:
         - Call `await navigateAfterCallback(callbackPath || '/')`.
         - On success:
           - Emit `loginCallbackAsync_navigated` with relevant context (e.g., `configurationName`, `callbackPath`).
         - On failure (promise rejection):
           - Emit `loginCallbackAsync_navigation_error` with the error and context.
           - Set component state to an error state so that the error callback UI is rendered instead of the success UI.
       - If `navigateAfterCallback` is not provided (default behavior):
         - Call current navigation logic: `history.replaceState(callbackPath || '/')`.
         - Schedule an asynchronous verification step (e.g., `setTimeout` or `requestAnimationFrame`) to:
           - Compare `window.location` (path/URL) with the intended `callbackPath`.
           - If it matches, emit `loginCallbackAsync_navigated`.
           - If it does not match after a short delay and, optionally, a single retry:
             - Emit `loginCallbackAsync_navigation_error`.
             - Set component state to an error state to render the error UI instead of a permanent success message.

4. **Preserve backward compatibility**
   - Ensure that if `navigateAfterCallback` is not supplied and consumers do not subscribe to the new events, behavior remains effectively the same as today, except for the additional internal checks and improved error handling.
   - Do not change existing prop names or event names; only add new optional capabilities.

5. **Testing and documentation**
   - Add unit tests / integration tests for both paths:
     - Default path with `history.replaceState` and navigation verification.
     - Custom `navigateAfterCallback` path (successful navigation and failure cases).
   - Where feasible, add browser-targeted tests or manual verification notes for iOS Safari and back-forward cache scenarios.
   - Update documentation to:
     - Describe the new `navigateAfterCallback` prop, including usage examples with popular routers.
     - Document the new events and how consumers can use them to implement watchdogs or recovery flows.

This plan keeps the current behavior intact while providing the new hooks and signals needed to detect and handle cases where post-callback navigation does not actually commit.
Additional description: Add an optional async `navigateAfterCallback` hook to the callback flow, introduce navigation-commit and navigation-error events, and update the callback component to verify that post-login navigation has actually committed (with proper error signaling), improving resilience on Safari and similar edge cases.
This operation was performed by an AI via GnOuGo, the cute little bear who just wants to be adopted: https://github.com/GnouGo/GnouGo
