### PR TITLE
Auto fix for issue #1681: OidcProvider can sit in loading/authenticating indefinitely with no timeout event

### DIFF
--- a/packages/oidc-client/src/events.ts
+++ b/packages/oidc-client/src/events.ts
@@ -27,4 +27,5 @@ export const eventNames = {
   syncTokensAsync_end: 'syncTokensAsync_end',
   syncTokensAsync_error: 'syncTokensAsync_error',
   tokensInvalidAndWaitingActionsToRefresh: 'tokensInvalidAndWaitingActionsToRefresh',
+  loadingTimeout_error: 'loadingTimeout_error',
 };

--- a/packages/oidc-client/src/types.ts
+++ b/packages/oidc-client/src/types.ts
@@ -46,6 +46,7 @@ export type OidcConfiguration = {
   demonstrating_proof_of_possession?: boolean;
   demonstrating_proof_of_possession_configuration?: DemonstratingProofOfPossessionConfiguration;
   preload_user_info?: boolean;
+  loading_timeout_ms?: number;
 };
 
 export interface DemonstratingProofOfPossessionConfiguration {

--- a/packages/react-oidc/src/OidcProvider.spec.tsx
+++ b/packages/react-oidc/src/OidcProvider.spec.tsx
@@ -1,17 +1,17 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let mockEventSubscribers: Array<{ id: string; func: (name: string, data: any) => void }> = [];
 const mockPublishEvent = vi.fn((eventName, data) => {
-  mockEventSubscribers.forEach((sub) => sub.func(eventName, data));
+  mockEventSubscribers.forEach(sub => sub.func(eventName, data));
 });
-const mockSubscribeEvents = vi.fn((func) => {
+const mockSubscribeEvents = vi.fn(func => {
   const id = Math.random().toString();
   mockEventSubscribers.push({ id, func });
   return id;
 });
-const mockRemoveEventSubscription = vi.fn((id) => {
-  mockEventSubscribers = mockEventSubscribers.filter((e) => e.id !== id);
+const mockRemoveEventSubscription = vi.fn(id => {
+  mockEventSubscribers = mockEventSubscribers.filter(e => e.id !== id);
 });
 
 vi.mock('@axa-fr/oidc-client', () => ({
@@ -71,11 +71,17 @@ vi.mock('@axa-fr/oidc-client', () => ({
     },
   },
   OidcLocation: class {
-    getCurrentHref() { return 'http://localhost/'; }
-    getPath() { return '/'; }
+    getCurrentHref() {
+      return 'http://localhost/';
+    }
+    getPath() {
+      return '/';
+    }
     open() {}
     reload() {}
-    getOrigin() { return 'http://localhost'; }
+    getOrigin() {
+      return 'http://localhost';
+    }
   },
   getFetchDefault: vi.fn(() => fetch),
 }));
@@ -134,7 +140,7 @@ describe('OidcProvider loading timeout', () => {
 
     // Simulate loginAsync_begin event
     act(() => {
-      mockEventSubscribers.forEach((sub) => sub.func('loginAsync_begin', {}));
+      mockEventSubscribers.forEach(sub => sub.func('loginAsync_begin', {}));
     });
 
     // Reset to track timeout event specifically
@@ -181,10 +187,7 @@ describe('OidcProvider loading timeout', () => {
       vi.advanceTimersByTime(60_000);
     });
 
-    expect(mockPublishEvent).not.toHaveBeenCalledWith(
-      'loadingTimeout_error',
-      expect.anything(),
-    );
+    expect(mockPublishEvent).not.toHaveBeenCalledWith('loadingTimeout_error', expect.anything());
   });
 
   it('should NOT fire loadingTimeout_error when loading_timeout_ms is negative (disabled)', async () => {
@@ -201,10 +204,7 @@ describe('OidcProvider loading timeout', () => {
       vi.advanceTimersByTime(60_000);
     });
 
-    expect(mockPublishEvent).not.toHaveBeenCalledWith(
-      'loadingTimeout_error',
-      expect.anything(),
-    );
+    expect(mockPublishEvent).not.toHaveBeenCalledWith('loadingTimeout_error', expect.anything());
   });
 
   it('should NOT fire loadingTimeout_error if provider leaves loading state before deadline', async () => {
@@ -224,7 +224,7 @@ describe('OidcProvider loading timeout', () => {
 
     // Simulate successful callback (leaving loading state)
     act(() => {
-      mockEventSubscribers.forEach((sub) => sub.func('loginCallbackAsync_end', {}));
+      mockEventSubscribers.forEach(sub => sub.func('loginCallbackAsync_end', {}));
     });
 
     mockPublishEvent.mockClear();
@@ -234,10 +234,7 @@ describe('OidcProvider loading timeout', () => {
       vi.advanceTimersByTime(500);
     });
 
-    expect(mockPublishEvent).not.toHaveBeenCalledWith(
-      'loadingTimeout_error',
-      expect.anything(),
-    );
+    expect(mockPublishEvent).not.toHaveBeenCalledWith('loadingTimeout_error', expect.anything());
   });
 
   it('should use default timeout of 30000ms when loading_timeout_ms is not configured', async () => {
@@ -251,10 +248,7 @@ describe('OidcProvider loading timeout', () => {
       vi.advanceTimersByTime(29_999);
     });
 
-    expect(mockPublishEvent).not.toHaveBeenCalledWith(
-      'loadingTimeout_error',
-      expect.anything(),
-    );
+    expect(mockPublishEvent).not.toHaveBeenCalledWith('loadingTimeout_error', expect.anything());
 
     act(() => {
       vi.advanceTimersByTime(1);

--- a/packages/react-oidc/src/OidcProvider.spec.tsx
+++ b/packages/react-oidc/src/OidcProvider.spec.tsx
@@ -1,0 +1,285 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mockEventSubscribers: Array<{ id: string; func: (name: string, data: any) => void }> = [];
+const mockPublishEvent = vi.fn((eventName, data) => {
+  mockEventSubscribers.forEach((sub) => sub.func(eventName, data));
+});
+const mockSubscribeEvents = vi.fn((func) => {
+  const id = Math.random().toString();
+  mockEventSubscribers.push({ id, func });
+  return id;
+});
+const mockRemoveEventSubscription = vi.fn((id) => {
+  mockEventSubscribers = mockEventSubscribers.filter((e) => e.id !== id);
+});
+
+vi.mock('@axa-fr/oidc-client', () => ({
+  OidcClient: {
+    getOrCreate: vi.fn(() => () => ({
+      subscribeEvents: mockSubscribeEvents,
+      removeEventSubscription: mockRemoveEventSubscription,
+      publishEvent: mockPublishEvent,
+      configuration: {
+        redirect_uri: 'http://localhost/callback',
+        silent_redirect_uri: 'http://localhost/silent-callback',
+        silent_login_uri: 'http://localhost/silent-login',
+      },
+      tryKeepExistingSessionAsync: vi.fn().mockResolvedValue(true),
+    })),
+    get: vi.fn(() => ({
+      subscribeEvents: mockSubscribeEvents,
+      removeEventSubscription: mockRemoveEventSubscription,
+      publishEvent: mockPublishEvent,
+      configuration: {
+        redirect_uri: 'http://localhost/callback',
+        silent_redirect_uri: 'http://localhost/silent-callback',
+        silent_login_uri: 'http://localhost/silent-login',
+      },
+      tryKeepExistingSessionAsync: vi.fn().mockResolvedValue(true),
+    })),
+    eventNames: {
+      service_worker_not_supported_by_browser: 'service_worker_not_supported_by_browser',
+      token_acquired: 'token_acquired',
+      logout_from_another_tab: 'logout_from_another_tab',
+      logout_from_same_tab: 'logout_from_same_tab',
+      token_renewed: 'token_renewed',
+      token_timer: 'token_timer',
+      loginAsync_begin: 'loginAsync_begin',
+      loginAsync_error: 'loginAsync_error',
+      loginCallbackAsync_begin: 'loginCallbackAsync_begin',
+      loginCallbackAsync_end: 'loginCallbackAsync_end',
+      loginCallbackAsync_error: 'loginCallbackAsync_error',
+      refreshTokensAsync_begin: 'refreshTokensAsync_begin',
+      refreshTokensAsync: 'refreshTokensAsync',
+      refreshTokensAsync_end: 'refreshTokensAsync_end',
+      refreshTokensAsync_error: 'refreshTokensAsync_error',
+      refreshTokensAsync_silent_error: 'refreshTokensAsync_silent_error',
+      tryKeepExistingSessionAsync_begin: 'tryKeepExistingSessionAsync_begin',
+      tryKeepExistingSessionAsync_end: 'tryKeepExistingSessionAsync_end',
+      tryKeepExistingSessionAsync_error: 'tryKeepExistingSessionAsync_error',
+      silentLoginAsync_begin: 'silentLoginAsync_begin',
+      silentLoginAsync: 'silentLoginAsync',
+      silentLoginAsync_end: 'silentLoginAsync_end',
+      silentLoginAsync_error: 'silentLoginAsync_error',
+      syncTokensAsync_begin: 'syncTokensAsync_begin',
+      syncTokensAsync_lock_not_available: 'syncTokensAsync_lock_not_available',
+      syncTokensAsync_end: 'syncTokensAsync_end',
+      syncTokensAsync_error: 'syncTokensAsync_error',
+      tokensInvalidAndWaitingActionsToRefresh: 'tokensInvalidAndWaitingActionsToRefresh',
+      loadingTimeout_error: 'loadingTimeout_error',
+    },
+  },
+  OidcLocation: class {
+    getCurrentHref() { return 'http://localhost/'; }
+    getPath() { return '/'; }
+    open() {}
+    reload() {}
+    getOrigin() { return 'http://localhost'; }
+  },
+  getFetchDefault: vi.fn(() => fetch),
+}));
+
+vi.mock('./core/routes/OidcRoutes.js', () => ({
+  default: ({ children }: any) => <div data-testid="oidc-routes">{children}</div>,
+}));
+
+import { OidcProvider } from './OidcProvider';
+
+describe('OidcProvider loading timeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockEventSubscribers = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const baseConfiguration = {
+    client_id: 'test-client',
+    redirect_uri: 'http://localhost/callback',
+    silent_redirect_uri: 'http://localhost/silent-callback',
+    scope: 'openid',
+    authority: 'http://localhost/authority',
+  };
+
+  it('should fire loadingTimeout_error when stuck in initial loading state', async () => {
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 100 }}
+        configurationName="default"
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(mockPublishEvent).toHaveBeenCalledWith('loadingTimeout_error', { timeoutMs: 100 });
+  });
+
+  it('should fire loadingTimeout_error when stuck in loginAsync_begin state', async () => {
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 200 }}
+        configurationName="default"
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    // Simulate loginAsync_begin event
+    act(() => {
+      mockEventSubscribers.forEach((sub) => sub.func('loginAsync_begin', {}));
+    });
+
+    // Reset to track timeout event specifically
+    mockPublishEvent.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(mockPublishEvent).toHaveBeenCalledWith('loadingTimeout_error', { timeoutMs: 200 });
+  });
+
+  it('should render loadingTimeoutComponent when loadingTimeout_error is triggered', async () => {
+    const CustomTimeoutComponent = () => <div data-testid="custom-timeout">Timeout!</div>;
+
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 50 }}
+        configurationName="default"
+        loadingTimeoutComponent={CustomTimeoutComponent}
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(screen.getByTestId('custom-timeout')).toBeTruthy();
+  });
+
+  it('should NOT fire loadingTimeout_error when loading_timeout_ms is 0 (disabled)', async () => {
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 0 }}
+        configurationName="default"
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(mockPublishEvent).not.toHaveBeenCalledWith(
+      'loadingTimeout_error',
+      expect.anything(),
+    );
+  });
+
+  it('should NOT fire loadingTimeout_error when loading_timeout_ms is negative (disabled)', async () => {
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: -1 }}
+        configurationName="default"
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(mockPublishEvent).not.toHaveBeenCalledWith(
+      'loadingTimeout_error',
+      expect.anything(),
+    );
+  });
+
+  it('should NOT fire loadingTimeout_error if provider leaves loading state before deadline', async () => {
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 500 }}
+        configurationName="default"
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    // Advance partway
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // Simulate successful callback (leaving loading state)
+    act(() => {
+      mockEventSubscribers.forEach((sub) => sub.func('loginCallbackAsync_end', {}));
+    });
+
+    mockPublishEvent.mockClear();
+
+    // Advance past original timeout
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockPublishEvent).not.toHaveBeenCalledWith(
+      'loadingTimeout_error',
+      expect.anything(),
+    );
+  });
+
+  it('should use default timeout of 30000ms when loading_timeout_ms is not configured', async () => {
+    render(
+      <OidcProvider configuration={baseConfiguration} configurationName="default">
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(29_999);
+    });
+
+    expect(mockPublishEvent).not.toHaveBeenCalledWith(
+      'loadingTimeout_error',
+      expect.anything(),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(mockPublishEvent).toHaveBeenCalledWith('loadingTimeout_error', { timeoutMs: 30_000 });
+  });
+
+  it('should propagate loadingTimeout_error through onEvent callback', async () => {
+    const onEvent = vi.fn();
+
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 100 }}
+        configurationName="default"
+        onEvent={onEvent}
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(onEvent).toHaveBeenCalledWith('default', 'loadingTimeout_error', { timeoutMs: 100 });
+  });
+});

--- a/packages/react-oidc/src/OidcProvider.tsx
+++ b/packages/react-oidc/src/OidcProvider.tsx
@@ -193,9 +193,7 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
     if (timeoutMs <= 0) {
       return;
     }
-    const isStuck =
-      event.name === '' ||
-      event.name === OidcClient.eventNames.loginAsync_begin;
+    const isStuck = event.name === '' || event.name === OidcClient.eventNames.loginAsync_begin;
     if (!isStuck) {
       return;
     }

--- a/packages/react-oidc/src/OidcProvider.tsx
+++ b/packages/react-oidc/src/OidcProvider.tsx
@@ -13,6 +13,7 @@ import {
   Authenticating,
   CallBackSuccess,
   Loading,
+  LoadingTimeout,
   SessionLost,
 } from './core/default-component/index.js';
 import ServiceWorkerNotSupported from './core/default-component/ServiceWorkerNotSupported.component.js';
@@ -31,6 +32,7 @@ export type OidcProviderProps = {
   authenticatingComponent?: ComponentType<any>;
   authenticatingErrorComponent?: ComponentType<any>;
   loadingComponent?: ComponentType<any>;
+  loadingTimeoutComponent?: ComponentType<any>;
   serviceWorkerNotSupportedComponent?: ComponentType<any>;
   configurationName?: string;
   configuration?: OidcConfiguration;
@@ -84,6 +86,8 @@ const Switch = ({ isLoading, loadingComponent, children, configurationName }) =>
   return <>{children}</>;
 };
 
+const DEFAULT_LOADING_TIMEOUT_MS = 30_000;
+
 export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
   children,
   configuration,
@@ -91,6 +95,7 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
   callbackSuccessComponent = CallBackSuccess,
   authenticatingComponent = Authenticating,
   loadingComponent = Loading,
+  loadingTimeoutComponent = LoadingTimeout,
   serviceWorkerNotSupportedComponent = ServiceWorkerNotSupported,
   authenticatingErrorComponent = AuthenticatingError,
   sessionLostComponent = SessionLost,
@@ -155,6 +160,8 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
           onLogoutFromSameTab();
         }
         // setEvent({name, data});
+      } else if (name === OidcClient.eventNames.loadingTimeout_error) {
+        setEvent({ name, data });
       } else if (
         name === OidcClient.eventNames.loginAsync_begin ||
         name === OidcClient.eventNames.loginCallbackAsync_end ||
@@ -181,9 +188,28 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
     };
   }, [configuration, configurationName]);
 
+  useEffect(() => {
+    const timeoutMs = configuration?.loading_timeout_ms ?? DEFAULT_LOADING_TIMEOUT_MS;
+    if (timeoutMs <= 0) {
+      return;
+    }
+    const isStuck =
+      event.name === '' ||
+      event.name === OidcClient.eventNames.loginAsync_begin;
+    if (!isStuck) {
+      return;
+    }
+    const timeoutId = setTimeout(() => {
+      const oidcInstance = getOidc(configurationName);
+      oidcInstance.publishEvent(OidcClient.eventNames.loadingTimeout_error, { timeoutMs });
+    }, timeoutMs);
+    return () => clearTimeout(timeoutId);
+  }, [event.name, configurationName, configuration]);
+
   const SessionLostComponent = sessionLostComponent;
   const AuthenticatingComponent = authenticatingComponent;
   const LoadingComponent = loadingComponent;
+  const LoadingTimeoutComponent = loadingTimeoutComponent;
   const ServiceWorkerNotSupportedComponent = serviceWorkerNotSupportedComponent;
   const AuthenticatingErrorComponent = authenticatingErrorComponent;
 
@@ -209,6 +235,16 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
           configurationName={configurationName}
         >
           <AuthenticatingComponent configurationName={configurationName} />
+        </Switch>
+      );
+    case OidcClient.eventNames.loadingTimeout_error:
+      return (
+        <Switch
+          loadingComponent={LoadingComponent}
+          isLoading={isLoading}
+          configurationName={configurationName}
+        >
+          <LoadingTimeoutComponent configurationName={configurationName} />
         </Switch>
       );
     case OidcClient.eventNames.loginAsync_error:

--- a/packages/react-oidc/src/core/default-component/LoadingTimeout.component.tsx
+++ b/packages/react-oidc/src/core/default-component/LoadingTimeout.component.tsx
@@ -1,0 +1,14 @@
+import { ComponentType } from 'react';
+
+const LoadingTimeout: ComponentType<any> = () => (
+  <div className="oidc-loading-timeout">
+    <div className="oidc-loading-timeout__container">
+      <h1 className="oidc-loading-timeout__title">Loading timeout</h1>
+      <p className="oidc-loading-timeout__content">
+        Authentication is taking longer than expected. Please try refreshing the page.
+      </p>
+    </div>
+  </div>
+);
+
+export default LoadingTimeout;

--- a/packages/react-oidc/src/core/default-component/index.ts
+++ b/packages/react-oidc/src/core/default-component/index.ts
@@ -2,5 +2,6 @@ export { default as AuthenticateError } from './AuthenticateError.component.js';
 export { default as Authenticating } from './Authenticating.component.js';
 export { default as Callback, CallBackSuccess } from './Callback.component.js';
 export { default as Loading } from './Loading.component.js';
+export { default as LoadingTimeout } from './LoadingTimeout.component.js';
 export { default as ServiceWorkerNotSupported } from './ServiceWorkerNotSupported.component.js';
 export { default as SessionLost } from './SessionLost.component.js';


### PR DESCRIPTION
This pull request was created automatically for issue #1681 (https://github.com/AxaFrance/oidc-client/issues/1681).
Summary of the need: `OidcProvider` can remain indefinitely in its loading/authenticating state when the underlying auth flow stalls, leaving users stuck on a spinner with no error signal or timeout. This happens particularly under load with multiple tabs and slow conditions, and forces consumers to implement their own ad‑hoc timers and reload logic. The reporter proposes adding a configurable loading-timeout that emits a dedicated error event so apps can present recovery UI, and separately investigating the suspected cross-tab race that causes the stall. This would centralize watchdog behavior in the library and reduce brittle consumer workarounds.
Implementation plan and notes from Copilot Ask: 1. Add a new event name `loadingTimeout_error` to `packages/oidc-client/src/events.ts`, and update any related event typings so it is part of the public event set.
2. Extend `OidcConfiguration` in `packages/oidc-client/src/types.ts` with an optional property `loading_timeout_ms?: number;`, documented as a configurable loading/authentication timeout in milliseconds (default ~30s, 0/negative values disable the watchdog).
3. In `packages/react-oidc/src/OidcProvider.tsx`, read `loading_timeout_ms` from the active configuration, falling back to the default value.
4. Add a `useEffect` in `OidcProvider` that:
   - Detects when the provider is “stuck” in a loading/authenticating state (e.g., `isLoading === true` or selected event names like `loginAsync_begin`).
   - Starts a `setTimeout` for `timeoutMs` when entering such a state, unless `timeoutMs <= 0`.
   - On timeout, checks that the provider is still in the loading/authenticating state; if so, obtains the `oidc` instance for the current configuration and calls `oidc.publishEvent(eventNames.loadingTimeout_error, { timeoutMs })`, and optionally updates the local `event` state to the same value.
   - Cleans up by clearing the timeout on state changes, configuration changes, or component unmount.
5. In the `OidcProvider` event-handling/rendering logic, add a case for `loadingTimeout_error` that renders an appropriate error UI, initially reusing `authenticatingErrorComponent` (or similar existing error component) so consumers can immediately surface a recovery screen.
6. Ensure the new `loadingTimeout_error` event is naturally propagated through the existing `onEvent` callback so applications can hook into it without additional plumbing.
7. Update documentation:
   - Describe `loading_timeout_ms`, its default value, and how to disable it.
   - Document the new `loadingTimeout_error` event and its payload.
   - Optionally add a short example of using `onEvent` and/or custom components to implement a recovery strategy on timeout.
8. Add or update tests to cover:
   - Emission of `loadingTimeout_error` when the provider remains in loading/authenticating beyond `loading_timeout_ms`.
   - No timeout event when the provider exits loading/authenticating before the deadline.
   - Behavior when `loading_timeout_ms` is disabled (0 or negative).
Additional description: Add a configurable loading/authentication timeout to `OidcProvider` that emits a new `loadingTimeout_error` event via the existing event system, allowing applications to detect and handle stalled OIDC flows instead of remaining indefinitely on the loading/authenticating UI.
This operation was performed by an AI via GnOuGo, the cute little bear who just wants to be adopted: https://github.com/GnouGo/GnouGo
