### PR TITLE
Fix: loadingTimeout_error fires on authenticated/idle state after a silent session restore (regression   from #1681 / #1692) (issue #1696)

### DIFF
--- a/packages/react-oidc/src/OidcProvider.spec.tsx
+++ b/packages/react-oidc/src/OidcProvider.spec.tsx
@@ -14,30 +14,30 @@ const mockRemoveEventSubscription = vi.fn(id => {
   mockEventSubscribers = mockEventSubscribers.filter(e => e.id !== id);
 });
 
+const mockOidcInstance: {
+  subscribeEvents: typeof mockSubscribeEvents;
+  removeEventSubscription: typeof mockRemoveEventSubscription;
+  publishEvent: typeof mockPublishEvent;
+  configuration: Record<string, string>;
+  tryKeepExistingSessionAsync: ReturnType<typeof vi.fn>;
+  tokens: unknown;
+} = {
+  subscribeEvents: mockSubscribeEvents,
+  removeEventSubscription: mockRemoveEventSubscription,
+  publishEvent: mockPublishEvent,
+  configuration: {
+    redirect_uri: 'http://localhost/callback',
+    silent_redirect_uri: 'http://localhost/silent-callback',
+    silent_login_uri: 'http://localhost/silent-login',
+  },
+  tryKeepExistingSessionAsync: vi.fn().mockResolvedValue(true),
+  tokens: null,
+};
+
 vi.mock('@axa-fr/oidc-client', () => ({
   OidcClient: {
-    getOrCreate: vi.fn(() => () => ({
-      subscribeEvents: mockSubscribeEvents,
-      removeEventSubscription: mockRemoveEventSubscription,
-      publishEvent: mockPublishEvent,
-      configuration: {
-        redirect_uri: 'http://localhost/callback',
-        silent_redirect_uri: 'http://localhost/silent-callback',
-        silent_login_uri: 'http://localhost/silent-login',
-      },
-      tryKeepExistingSessionAsync: vi.fn().mockResolvedValue(true),
-    })),
-    get: vi.fn(() => ({
-      subscribeEvents: mockSubscribeEvents,
-      removeEventSubscription: mockRemoveEventSubscription,
-      publishEvent: mockPublishEvent,
-      configuration: {
-        redirect_uri: 'http://localhost/callback',
-        silent_redirect_uri: 'http://localhost/silent-callback',
-        silent_login_uri: 'http://localhost/silent-login',
-      },
-      tryKeepExistingSessionAsync: vi.fn().mockResolvedValue(true),
-    })),
+    getOrCreate: vi.fn(() => () => mockOidcInstance),
+    get: vi.fn(() => mockOidcInstance),
     eventNames: {
       service_worker_not_supported_by_browser: 'service_worker_not_supported_by_browser',
       token_acquired: 'token_acquired',
@@ -97,6 +97,7 @@ describe('OidcProvider loading timeout', () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     mockEventSubscribers = [];
+    mockOidcInstance.tokens = null;
   });
 
   afterEach(() => {
@@ -255,6 +256,126 @@ describe('OidcProvider loading timeout', () => {
     });
 
     expect(mockPublishEvent).toHaveBeenCalledWith('loadingTimeout_error', { timeoutMs: 30_000 });
+  });
+
+  it('should NOT fire loadingTimeout_error after a silent session restore when authenticated', async () => {
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 500 }}
+        configurationName="default"
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // Simulate a successful silent session restore (no loginCallbackAsync_end is emitted).
+    act(() => {
+      mockEventSubscribers.forEach(sub =>
+        sub.func('tryKeepExistingSessionAsync_end', { success: true }),
+      );
+    });
+
+    mockPublishEvent.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(mockPublishEvent).not.toHaveBeenCalledWith('loadingTimeout_error', expect.anything());
+  });
+
+  it('should still fire loadingTimeout_error when silent session restore reports no existing session', async () => {
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 300 }}
+        configurationName="default"
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    act(() => {
+      mockEventSubscribers.forEach(sub =>
+        sub.func('tryKeepExistingSessionAsync_end', { success: false }),
+      );
+    });
+
+    mockPublishEvent.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(mockPublishEvent).toHaveBeenCalledWith('loadingTimeout_error', { timeoutMs: 300 });
+  });
+
+  it('should NOT fire loadingTimeout_error when token_acquired fires before the deadline', async () => {
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 400 }}
+        configurationName="default"
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    act(() => {
+      mockEventSubscribers.forEach(sub => sub.func('token_acquired', {}));
+    });
+
+    mockPublishEvent.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(mockPublishEvent).not.toHaveBeenCalledWith('loadingTimeout_error', expect.anything());
+  });
+
+  it('should NOT fire loadingTimeout_error when token_renewed fires before the deadline', async () => {
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 400 }}
+        configurationName="default"
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    act(() => {
+      mockEventSubscribers.forEach(sub => sub.func('token_renewed', {}));
+    });
+
+    mockPublishEvent.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(mockPublishEvent).not.toHaveBeenCalledWith('loadingTimeout_error', expect.anything());
+  });
+
+  it('should NOT arm the watchdog when the OIDC client mounts already authenticated', async () => {
+    mockOidcInstance.tokens = { accessToken: 'existing-token' };
+
+    render(
+      <OidcProvider
+        configuration={{ ...baseConfiguration, loading_timeout_ms: 100 }}
+        configurationName="default"
+      >
+        <div>App</div>
+      </OidcProvider>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(mockPublishEvent).not.toHaveBeenCalledWith('loadingTimeout_error', expect.anything());
   });
 
   it('should propagate loadingTimeout_error through onEvent callback', async () => {

--- a/packages/react-oidc/src/OidcProvider.tsx
+++ b/packages/react-oidc/src/OidcProvider.tsx
@@ -89,6 +89,30 @@ const Switch = ({ isLoading, loadingComponent, children, configurationName }) =>
 
 const DEFAULT_LOADING_TIMEOUT_MS = 30_000;
 
+/**
+ * Returns true when an event signals that the OIDC client has reached an
+ * authenticated, idle state and the loading watchdog should be disarmed.
+ *
+ * The default `event.name === ''` state in {@link OidcProvider} is overloaded:
+ * it represents both "not started yet" and "done and idle". A silent session
+ * restore via `tryKeepExistingSessionAsync` does not emit
+ * `loginCallbackAsync_end`, so without these explicit ready signals the
+ * watchdog would fire against a fully authenticated app.
+ */
+const isReadySignal = (name: string, data: unknown): boolean => {
+  if (
+    name === OidcClient.eventNames.token_acquired ||
+    name === OidcClient.eventNames.token_renewed ||
+    name === OidcClient.eventNames.loginCallbackAsync_end
+  ) {
+    return true;
+  }
+  if (name === OidcClient.eventNames.tryKeepExistingSessionAsync_end) {
+    return (data as { success?: boolean } | null)?.success === true;
+  }
+  return false;
+};
+
 export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
   children,
   configuration,
@@ -124,6 +148,7 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
 
   const loading = false;
   const [event, setEvent] = useState(defaultEventState);
+  const [isAuthenticatedAndIdle, setIsAuthenticatedAndIdle] = useState<boolean>(false);
   const [currentConfigurationName, setConfigurationName] = useState(configurationName);
 
   useEffect(() => {
@@ -142,6 +167,9 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
   useEffect(() => {
     const oidc = getOidc(configurationName);
     const newSubscriptionId = oidc.subscribeEvents((name, data) => {
+      if (isReadySignal(name, data)) {
+        setIsAuthenticatedAndIdle(true);
+      }
       if (
         name === OidcClient.eventNames.refreshTokensAsync_error ||
         name === OidcClient.eventNames.syncTokensAsync_error
@@ -187,6 +215,7 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
       const previousOidc = getOidc(configurationName);
       previousOidc.removeEventSubscription(newSubscriptionId);
       setEvent(defaultEventState);
+      setIsAuthenticatedAndIdle(false);
     };
   }, [configuration, configurationName]);
 
@@ -195,16 +224,24 @@ export const OidcProvider: FC<PropsWithChildren<OidcProviderProps>> = ({
     if (timeoutMs <= 0) {
       return;
     }
+    if (isAuthenticatedAndIdle) {
+      return;
+    }
+    const oidcInstance = getOidc(configurationName);
+    if (oidcInstance?.tokens != null) {
+      return;
+    }
     const isStuck = event.name === '' || event.name === OidcClient.eventNames.loginAsync_begin;
     if (!isStuck) {
       return;
     }
     const timeoutId = setTimeout(() => {
-      const oidcInstance = getOidc(configurationName);
-      oidcInstance.publishEvent(OidcClient.eventNames.loadingTimeout_error, { timeoutMs });
+      getOidc(configurationName).publishEvent(OidcClient.eventNames.loadingTimeout_error, {
+        timeoutMs,
+      });
     }, timeoutMs);
     return () => clearTimeout(timeoutId);
-  }, [event.name, configurationName, configuration]);
+  }, [event.name, isAuthenticatedAndIdle, configurationName, configuration]);
 
   const SessionLostComponent = sessionLostComponent;
   const AuthenticatingComponent = authenticatingComponent;


### PR DESCRIPTION
This pull request addresses issue #1696.

Summary of changes:
- Implements the requested bug.
- Applies clean code practices for readability and maintainability.
- Updates or adds tests where appropriate.

Fixes #1696.

---
_This action was performed by an AI via GnOuGo, the cute little bear who only wants to be adopted. See https://github.com/GnouGo/GnouGo for more details._

