### PR TITLE
Change for issue #1679: Relax OIDC hooks requirement to be inside OidcProvider

### DIFF
--- a/packages/react-oidc/README.md
+++ b/packages/react-oidc/README.md
@@ -449,6 +449,72 @@ const DisplayUserInfo = () => {
 };
 ```
 
+## Testing and Storybook: using `OidcMockProvider`
+
+When a component uses one of the OIDC hooks (`useOidc`, `useOidcUser`,
+`useOidcAccessToken`, `useOidcIdToken`, `useOidcFetch`) or `OidcSecure`,
+it does not need to be wrapped in a real `OidcProvider` in unit tests or
+Storybook stories: the hooks return safe unauthenticated defaults when no
+provider is mounted, and emit a one-time development warning so that
+genuine misconfigurations remain visible.
+
+For scenarios that need a specific simulated authentication state, the
+library ships an `OidcMockProvider` component that registers an in-memory
+mock client for its subtree:
+
+```jsx
+import {
+  OidcMockProvider,
+  useOidc,
+  useOidcUser,
+  useOidcAccessToken,
+} from '@axa-fr/react-oidc';
+
+const AuthenticatedScreen = () => {
+  const { isAuthenticated } = useOidc();
+  const { oidcUser } = useOidcUser();
+  const { accessToken } = useOidcAccessToken();
+  return (
+    <div>
+      <p>Authenticated: {String(isAuthenticated)}</p>
+      <p>User: {oidcUser?.name}</p>
+      <p>Access token: {accessToken}</p>
+    </div>
+  );
+};
+
+// In a test or Storybook story:
+<OidcMockProvider
+  configurationName="default"
+  value={{
+    isAuthenticated: true,
+    accessToken: 'fake-access-token',
+    idToken: 'fake-id-token',
+    user: { sub: '123', name: 'Jane Doe' },
+  }}
+>
+  <AuthenticatedScreen />
+</OidcMockProvider>;
+```
+
+For more advanced needs (custom `loginAsync` / `logoutAsync`
+implementations, manual setup in a test file, etc.) you can build and
+register a mock client imperatively:
+
+```js
+import { createMockOidcClient, registerMockOidcClient } from '@axa-fr/react-oidc';
+
+const mockClient = createMockOidcClient({
+  isAuthenticated: true,
+  user: { sub: '123', name: 'Jane Doe' },
+});
+registerMockOidcClient('default', mockClient);
+```
+
+Mock clients always take precedence over the real client registered by
+`OidcProvider`, which makes them ideal for unit tests, integration tests,
+and Storybook decorators.
+
 ## How to get a fetch that inject Access_Token: Hook method
 
 If you are not using the service worker. The Fetch function needs to send AccessToken.

--- a/packages/react-oidc/src/FetchToken.tsx
+++ b/packages/react-oidc/src/FetchToken.tsx
@@ -1,6 +1,8 @@
 import { Fetch, OidcClient } from '@axa-fr/oidc-client';
 import { useCallback } from 'react';
 
+import { tryGetOidcClient } from './oidcClientRegistry.js';
+
 export interface ComponentWithOidcFetchProps {
   fetch?: Fetch;
 }
@@ -15,6 +17,11 @@ const fetchWithToken =
   ) =>
   async (...params: Parameters<Fetch>) => {
     const oidc = getOidcWithConfigurationName();
+    // When no OIDC client is registered (e.g. in tests / Storybook),
+    // fall back to the plain fetch so callers do not crash.
+    if (!oidc) {
+      return await fetch(...params);
+    }
     const newFetch = oidc.fetchWithTokens(fetch, demonstratingProofOfPossession);
     return await newFetch(...params);
   };
@@ -41,11 +48,11 @@ export const useOidcFetch = (
   demonstratingProofOfPossession: boolean = false,
 ) => {
   const previousFetch = fetch || window.fetch;
-  const getOidc = OidcClient.get;
 
   const memoizedFetchCallback = useCallback(
     (input: RequestInfo | URL, init?: RequestInit) => {
-      const getOidcWithConfigurationName = () => getOidc(configurationName);
+      const getOidcWithConfigurationName = () =>
+        tryGetOidcClient(configurationName) as OidcClient | null;
       const newFetch = fetchWithToken(
         previousFetch,
         getOidcWithConfigurationName,

--- a/packages/react-oidc/src/OidcMockProvider.spec.tsx
+++ b/packages/react-oidc/src/OidcMockProvider.spec.tsx
@@ -1,0 +1,150 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGet = vi.fn();
+
+vi.mock('@axa-fr/oidc-client', () => ({
+  OidcClient: {
+    get: (...args: unknown[]) => mockGet(...args),
+    eventNames: {
+      token_acquired: 'token_acquired',
+      token_renewed: 'token_renewed',
+      logout_from_another_tab: 'logout_from_another_tab',
+      logout_from_same_tab: 'logout_from_same_tab',
+      refreshTokensAsync_error: 'refreshTokensAsync_error',
+      syncTokensAsync_error: 'syncTokensAsync_error',
+    },
+  },
+}));
+
+import {
+  __resetOidcClientRegistryForTests,
+  registerMockOidcClient,
+  tryGetOidcClient,
+  unregisterMockOidcClient,
+} from './oidcClientRegistry';
+import { OidcMockProvider } from './OidcMockProvider';
+import { useOidc, useOidcAccessToken, useOidcIdToken } from './ReactOidc';
+import { OidcUserStatus, useOidcUser } from './User';
+
+describe('OidcMockProvider', () => {
+  beforeEach(() => {
+    __resetOidcClientRegistryForTests();
+    mockGet.mockReset();
+    mockGet.mockImplementation(() => {
+      throw new Error('OIDC library does seem initialized.');
+    });
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const wrapperFor = (value: Parameters<typeof OidcMockProvider>[0]['value']) => {
+    const Wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+      <OidcMockProvider value={value}>{children}</OidcMockProvider>
+    );
+    return Wrapper;
+  };
+
+  it('provides an authenticated state to useOidc', () => {
+    const { result } = renderHook(() => useOidc(), {
+      wrapper: wrapperFor({ isAuthenticated: true, accessToken: 'fake-access-token' }),
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('exposes mocked access and id tokens to the token hooks', () => {
+    const accessTokenResult = renderHook(() => useOidcAccessToken(), {
+      wrapper: wrapperFor({
+        isAuthenticated: true,
+        accessToken: 'mock-access-token',
+        accessTokenPayload: { sub: '123' },
+      }),
+    });
+
+    expect(accessTokenResult.result.current.accessToken).toBe('mock-access-token');
+    expect(accessTokenResult.result.current.accessTokenPayload).toEqual({ sub: '123' });
+
+    const idTokenResult = renderHook(() => useOidcIdToken(), {
+      wrapper: wrapperFor({
+        isAuthenticated: true,
+        idToken: 'mock-id-token',
+        idTokenPayload: { sub: '123', name: 'Jane' },
+      }),
+    });
+
+    expect(idTokenResult.result.current.idToken).toBe('mock-id-token');
+    expect(idTokenResult.result.current.idTokenPayload).toEqual({ sub: '123', name: 'Jane' });
+  });
+
+  it('exposes a mocked user info object to useOidcUser', () => {
+    const user = { sub: 'user-1', name: 'Jane Doe' };
+    const { result } = renderHook(() => useOidcUser(), {
+      wrapper: wrapperFor({ isAuthenticated: true, user }),
+    });
+
+    expect(result.current.oidcUser).toEqual(user);
+    expect(result.current.oidcUserLoadingState).toBe(OidcUserStatus.Loaded);
+  });
+
+  it('falls back to unauthenticated state when isAuthenticated is false', () => {
+    const { result } = renderHook(() => useOidc(), {
+      wrapper: wrapperFor({ isAuthenticated: false }),
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('renders its children', () => {
+    render(
+      <OidcMockProvider value={{ isAuthenticated: true }}>
+        <span>protected content</span>
+      </OidcMockProvider>,
+    );
+
+    expect(screen.getByText('protected content')).toBeTruthy();
+  });
+
+  it('unregisters the mock client when unmounted so later hook calls return null', () => {
+    const { unmount } = render(
+      <OidcMockProvider configurationName="scoped" value={{ isAuthenticated: true }}>
+        <span>child</span>
+      </OidcMockProvider>,
+    );
+
+    expect(tryGetOidcClient('scoped')).not.toBeNull();
+    unmount();
+    expect(tryGetOidcClient('scoped')).toBeNull();
+  });
+});
+
+describe('registerMockOidcClient / unregisterMockOidcClient', () => {
+  beforeEach(() => {
+    __resetOidcClientRegistryForTests();
+    mockGet.mockReset();
+    mockGet.mockImplementation(() => {
+      throw new Error('OIDC library does seem initialized.');
+    });
+  });
+
+  it('allows imperative registration of a custom mock client', () => {
+    const fakeClient = { tokens: { accessToken: 'imperative' } };
+    registerMockOidcClient('imperative', fakeClient);
+
+    expect(tryGetOidcClient('imperative')).toBe(fakeClient);
+
+    unregisterMockOidcClient('imperative');
+    expect(tryGetOidcClient('imperative')).toBeNull();
+  });
+
+  it('takes precedence over the real OidcClient.get when both are registered', () => {
+    mockGet.mockReturnValue({ tokens: { accessToken: 'real' } });
+    const fakeClient = { tokens: { accessToken: 'mock' } };
+    registerMockOidcClient('default', fakeClient);
+
+    expect(tryGetOidcClient('default')).toBe(fakeClient);
+  });
+});

--- a/packages/react-oidc/src/OidcMockProvider.tsx
+++ b/packages/react-oidc/src/OidcMockProvider.tsx
@@ -1,0 +1,177 @@
+import { OidcUserInfo } from '@axa-fr/oidc-client';
+import { FC, PropsWithChildren, useEffect, useMemo, useRef } from 'react';
+
+import {
+  OidcClientLike,
+  registerMockOidcClient,
+  unregisterMockOidcClient,
+} from './oidcClientRegistry.js';
+
+/**
+ * Tokens exposed by a mock OIDC client. Shape matches the subset of the
+ * real `Tokens` object consumed by the React hooks.
+ */
+export interface OidcMockTokens {
+  accessToken?: string | null;
+  accessTokenPayload?: unknown;
+  idToken?: string | null;
+  idTokenPayload?: unknown;
+}
+
+/**
+ * Declarative description of the OIDC state you want the hooks to
+ * observe in a test or Storybook story.
+ */
+export interface OidcMockValue<T extends OidcUserInfo = OidcUserInfo> {
+  /** Whether the simulated session is authenticated. Defaults to `false`. */
+  isAuthenticated?: boolean;
+  /** Convenience shortcut – sets `tokens.accessToken`. */
+  accessToken?: string | null;
+  /** Convenience shortcut – sets `tokens.accessTokenPayload`. */
+  accessTokenPayload?: unknown;
+  /** Convenience shortcut – sets `tokens.idToken`. */
+  idToken?: string | null;
+  /** Convenience shortcut – sets `tokens.idTokenPayload`. */
+  idTokenPayload?: unknown;
+  /** Full tokens object. When provided, takes precedence over the convenience props. */
+  tokens?: OidcMockTokens | null;
+  /** User info returned by `useOidcUser`. */
+  user?: T | null;
+  /** Whether DPoP support should be advertised on the mock configuration. */
+  demonstrating_proof_of_possession?: boolean;
+  /** Optional overrides for the async OIDC client methods. */
+  loginAsync?: (...args: unknown[]) => Promise<unknown>;
+  logoutAsync?: (...args: unknown[]) => Promise<unknown>;
+  renewTokensAsync?: (...args: unknown[]) => Promise<unknown>;
+}
+
+export interface OidcMockProviderProps<T extends OidcUserInfo = OidcUserInfo> {
+  /** OIDC configuration name to mock. Defaults to `"default"`. */
+  configurationName?: string;
+  /** Declarative description of the mocked state. */
+  value?: OidcMockValue<T>;
+}
+
+const buildTokens = (value: OidcMockValue): OidcMockTokens | null => {
+  if (value.tokens !== undefined) {
+    return value.tokens;
+  }
+  if (value.isAuthenticated === false) {
+    return null;
+  }
+  const hasAnyToken =
+    value.accessToken != null ||
+    value.idToken != null ||
+    value.accessTokenPayload != null ||
+    value.idTokenPayload != null;
+  if (value.isAuthenticated || hasAnyToken) {
+    return {
+      accessToken: value.accessToken ?? null,
+      accessTokenPayload: value.accessTokenPayload ?? null,
+      idToken: value.idToken ?? null,
+      idTokenPayload: value.idTokenPayload ?? null,
+    };
+  }
+  return null;
+};
+
+/**
+ * Builds an in-memory mock OIDC client that satisfies the subset of the
+ * {@link OidcClient} API consumed by the React hooks
+ * (`useOidc`, `useOidcAccessToken`, `useOidcIdToken`, `useOidcUser`,
+ * `useOidcFetch`, `OidcSecure`).
+ *
+ * Exposed separately from {@link OidcMockProvider} so consumers can
+ * register it manually (e.g. in test setup files or Storybook decorators)
+ * via {@link registerMockOidcClient}.
+ */
+export const createMockOidcClient = <T extends OidcUserInfo = OidcUserInfo>(
+  value: OidcMockValue<T> = {},
+): OidcClientLike => {
+  const tokens = buildTokens(value);
+  const user = value.user ?? null;
+  const subscribers = new Map<string, (name: string, data: unknown) => void>();
+  let subscriptionId = 0;
+
+  const passthroughFetch = (fetch: typeof globalThis.fetch): typeof globalThis.fetch => fetch;
+
+  return {
+    tokens,
+    configuration: {
+      demonstrating_proof_of_possession: value.demonstrating_proof_of_possession ?? false,
+    },
+    userInfo: () => user,
+    userInfoAsync: async () => user,
+    subscribeEvents: (func: (name: string, data: unknown) => void) => {
+      const id = `mock-${++subscriptionId}`;
+      subscribers.set(id, func);
+      return id;
+    },
+    removeEventSubscription: (id: string) => {
+      subscribers.delete(id);
+    },
+    publishEvent: (name: string, data: unknown) => {
+      subscribers.forEach(func => func(name, data));
+    },
+    loginAsync: value.loginAsync ?? (async () => undefined),
+    logoutAsync: value.logoutAsync ?? (async () => undefined),
+    renewTokensAsync: value.renewTokensAsync ?? (async () => tokens),
+    tryKeepExistingSessionAsync: async () => tokens != null,
+    fetchWithTokens: passthroughFetch,
+    generateDemonstrationOfProofOfPossessionAsync: async () => '',
+  } as OidcClientLike;
+};
+
+/**
+ * React component that registers a mock OIDC client for the duration of
+ * its lifetime, so that descendants using `useOidc`, `useOidcUser`,
+ * `useOidcAccessToken`, `useOidcIdToken`, `useOidcFetch` or `OidcSecure`
+ * observe the simulated state without needing a real `OidcProvider`.
+ *
+ * The mock client takes precedence over any real client registered for
+ * the same `configurationName`. Use this in unit tests, Storybook stories,
+ * or any other environment where you want to control the OIDC state.
+ *
+ * @example
+ * ```tsx
+ * <OidcMockProvider
+ *   configurationName="default"
+ *   value={{ isAuthenticated: true, user: { sub: '123', name: 'Jane' } }}
+ * >
+ *   <MyAuthenticatedComponent />
+ * </OidcMockProvider>
+ * ```
+ */
+export const OidcMockProvider = <T extends OidcUserInfo = OidcUserInfo>({
+  configurationName = 'default',
+  value,
+  children,
+}: PropsWithChildren<OidcMockProviderProps<T>>): ReturnType<FC> => {
+  // Recompute the mock client whenever the supplied value changes so the
+  // simulated state stays in sync with the props.
+  const client = useMemo(() => createMockOidcClient<T>(value), [value]);
+
+  // Register synchronously during render so descendants observe the mock
+  // client on their very first render (before any effect runs).
+  registerMockOidcClient(configurationName, client);
+
+  // Keep a reference to the previously registered configuration name to
+  // clean it up if the prop changes.
+  const previousConfigurationNameRef = useRef<string>(configurationName);
+
+  useEffect(() => {
+    const previous = previousConfigurationNameRef.current;
+    if (previous !== configurationName) {
+      unregisterMockOidcClient(previous);
+      previousConfigurationNameRef.current = configurationName;
+    }
+    registerMockOidcClient(configurationName, client);
+    return () => {
+      unregisterMockOidcClient(configurationName);
+    };
+  }, [configurationName, client]);
+
+  return <>{children}</>;
+};
+
+export default OidcMockProvider;

--- a/packages/react-oidc/src/OidcSecure.tsx
+++ b/packages/react-oidc/src/OidcSecure.tsx
@@ -1,6 +1,8 @@
 import { OidcClient, StringMap } from '@axa-fr/oidc-client';
 import { FC, PropsWithChildren, useEffect } from 'react';
 
+import { tryGetOidcClient } from './oidcClientRegistry.js';
+
 export type OidcSecureProps = {
   callbackPath?: string;
   extras?: StringMap;
@@ -13,15 +15,14 @@ export const OidcSecure: FC<PropsWithChildren<OidcSecureProps>> = ({
   extras = null,
   configurationName = 'default',
 }) => {
-  const getOidc = OidcClient.get;
-  const oidc = getOidc(configurationName);
+  const oidc = tryGetOidcClient(configurationName) as OidcClient | null;
   useEffect(() => {
-    if (!oidc.tokens) {
+    if (oidc && !oidc.tokens) {
       oidc.loginAsync(callbackPath, extras);
     }
   }, [configurationName, callbackPath, extras]);
 
-  if (!oidc.tokens) {
+  if (!oidc || !oidc.tokens) {
     return null;
   }
   return <>{children}</>;

--- a/packages/react-oidc/src/ReactOidc.spec.tsx
+++ b/packages/react-oidc/src/ReactOidc.spec.tsx
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGet = vi.fn();
+
+vi.mock('@axa-fr/oidc-client', () => ({
+  OidcClient: {
+    get: (...args: unknown[]) => mockGet(...args),
+    eventNames: {
+      token_acquired: 'token_acquired',
+      token_renewed: 'token_renewed',
+      logout_from_another_tab: 'logout_from_another_tab',
+      logout_from_same_tab: 'logout_from_same_tab',
+      refreshTokensAsync_error: 'refreshTokensAsync_error',
+      syncTokensAsync_error: 'syncTokensAsync_error',
+    },
+  },
+}));
+
+import { __resetOidcClientRegistryForTests } from './oidcClientRegistry';
+import { useOidc, useOidcAccessToken, useOidcIdToken } from './ReactOidc';
+
+describe('React OIDC hooks without an OidcProvider', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    __resetOidcClientRegistryForTests();
+    mockGet.mockReset();
+    mockGet.mockImplementation(() => {
+      throw new Error('OIDC library does seem initialized.');
+    });
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('useOidc returns unauthenticated defaults and stable no-op callbacks', () => {
+    const { result } = renderHook(() => useOidc());
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(typeof result.current.login).toBe('function');
+    expect(typeof result.current.logout).toBe('function');
+    expect(typeof result.current.renewTokens).toBe('function');
+  });
+
+  it('useOidc.login / logout / renewTokens do not throw without a provider', async () => {
+    const { result } = renderHook(() => useOidc());
+
+    await expect(result.current.login()).resolves.toBeUndefined();
+    await expect(result.current.logout()).resolves.toBeUndefined();
+    await expect(result.current.renewTokens()).resolves.toEqual({
+      accessToken: null,
+      accessTokenPayload: null,
+      idToken: null,
+      idTokenPayload: null,
+    });
+  });
+
+  it('useOidcAccessToken returns null tokens without a provider', () => {
+    const { result } = renderHook(() => useOidcAccessToken());
+
+    expect(result.current.accessToken).toBeNull();
+    expect(result.current.accessTokenPayload).toBeNull();
+    expect(result.current.generateDemonstrationOfProofOfPossessionAsync).toBeNull();
+  });
+
+  it('useOidcIdToken returns null tokens without a provider', () => {
+    const { result } = renderHook(() => useOidcIdToken());
+
+    expect(result.current.idToken).toBeNull();
+    expect(result.current.idTokenPayload).toBeNull();
+  });
+
+  it('emits a development warning at most once per configuration name', () => {
+    renderHook(() => useOidc('storybook-config'));
+    renderHook(() => useOidc('storybook-config'));
+    renderHook(() => useOidcAccessToken('storybook-config'));
+
+    const warningsForConfig = warnSpy.mock.calls.filter(call =>
+      String(call[0]).includes('storybook-config'),
+    );
+    expect(warningsForConfig.length).toBe(1);
+  });
+
+  it('does not throw when OidcClient.get throws synchronously', () => {
+    expect(() => renderHook(() => useOidc())).not.toThrow();
+    expect(() => renderHook(() => useOidcAccessToken())).not.toThrow();
+    expect(() => renderHook(() => useOidcIdToken())).not.toThrow();
+  });
+});

--- a/packages/react-oidc/src/ReactOidc.tsx
+++ b/packages/react-oidc/src/ReactOidc.tsx
@@ -1,45 +1,51 @@
 import { OidcClient, StringMap, Tokens } from '@axa-fr/oidc-client';
 import { useEffect, useState } from 'react';
 
+import { OidcClientLike, tryGetOidcClient } from './oidcClientRegistry.js';
+
 const defaultConfigurationName = 'default';
 
-type GetOidcFn = {
-  (configurationName?: string): any;
+const hasTokens = (oidc: OidcClientLike | null): boolean => {
+  return oidc != null && (oidc as { tokens?: unknown }).tokens != null;
 };
 
-const defaultIsAuthenticated = (getOidc: GetOidcFn, configurationName: string) => {
-  let isAuthenticated = false;
-  const oidc = getOidc(configurationName);
-  if (oidc) {
-    isAuthenticated = getOidc(configurationName).tokens != null;
-  }
-  return isAuthenticated;
+const noop = (): void => {
+  // No-op when no OIDC client is registered. Documented in the README.
 };
+
+const emptyTokensResponse = (): OidcAccessToken & OidcIdToken => ({
+  accessToken: null,
+  accessTokenPayload: null,
+  idToken: null,
+  idTokenPayload: null,
+});
 
 export const useOidc = (configurationName = defaultConfigurationName) => {
-  const getOidc = OidcClient.get;
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(() =>
-    defaultIsAuthenticated(getOidc, configurationName),
+    hasTokens(tryGetOidcClient(configurationName)),
   );
 
   useEffect(() => {
     let isMounted = true;
-    const oidc = getOidc(configurationName);
+    const oidc = tryGetOidcClient(configurationName);
+    if (!oidc) {
+      return;
+    }
 
-    const newSubscriptionId = oidc.subscribeEvents((name: string, data: any) => {
+    const newSubscriptionId = (oidc as OidcClient).subscribeEvents((name: string, _data: any) => {
       if (
         name === OidcClient.eventNames.logout_from_another_tab ||
         name === OidcClient.eventNames.logout_from_same_tab ||
         name === OidcClient.eventNames.token_acquired
       ) {
         if (isMounted) {
-          setIsAuthenticated(defaultIsAuthenticated(getOidc, configurationName));
+          setIsAuthenticated(hasTokens(tryGetOidcClient(configurationName)));
         }
       }
     });
     return () => {
       isMounted = false;
-      oidc.removeEventSubscription(newSubscriptionId);
+      (oidc as OidcClient).removeEventSubscription(newSubscriptionId);
     };
   }, [configurationName]);
 
@@ -49,51 +55,60 @@ export const useOidc = (configurationName = defaultConfigurationName) => {
     silentLoginOnly = false,
     scope: string = undefined,
   ) => {
-    return getOidc(configurationName).loginAsync(
-      callbackPath,
-      extras,
-      false,
-      scope,
-      silentLoginOnly,
-    );
+    const oidc = tryGetOidcClient(configurationName) as OidcClient | null;
+    if (!oidc) {
+      return Promise.resolve();
+    }
+    return oidc.loginAsync(callbackPath, extras, false, scope, silentLoginOnly);
   };
   const logout = (
     callbackPath: string | null | undefined = undefined,
     extras: StringMap | undefined = undefined,
   ) => {
-    return getOidc(configurationName).logoutAsync(callbackPath, extras);
+    const oidc = tryGetOidcClient(configurationName) as OidcClient | null;
+    if (!oidc) {
+      return Promise.resolve();
+    }
+    return oidc.logoutAsync(callbackPath, extras);
   };
   const renewTokens = async (
     extras: StringMap | undefined = undefined,
   ): Promise<OidcAccessToken | OidcIdToken> => {
-    const tokens = await getOidc(configurationName).renewTokensAsync(extras);
+    const oidc = tryGetOidcClient(configurationName) as OidcClient | null;
+    if (!oidc) {
+      return emptyTokensResponse();
+    }
+    const tokens = (await oidc.renewTokensAsync(extras)) as unknown as Tokens;
 
     return {
       // @ts-ignore
-      accessToken: tokens.accessToken,
+      accessToken: tokens?.accessToken ?? null,
       // @ts-ignore
-      accessTokenPayload: tokens.accessTokenPayload,
+      accessTokenPayload: tokens?.accessTokenPayload ?? null,
       // @ts-ignore
-      idToken: tokens.idToken,
+      idToken: tokens?.idToken ?? null,
       // @ts-ignore
-      idTokenPayload: tokens.idTokenPayload,
+      idTokenPayload: tokens?.idTokenPayload ?? null,
     };
   };
   return { login, logout, renewTokens, isAuthenticated };
 };
 
-const accessTokenInitialState = { accessToken: null, accessTokenPayload: null };
+const accessTokenInitialState = {
+  accessToken: null,
+  accessTokenPayload: null,
+  generateDemonstrationOfProofOfPossessionAsync: null,
+};
 
-const initTokens = (configurationName: string) => {
-  const getOidc = OidcClient.get;
-  const oidc = getOidc(configurationName);
-  if (oidc.tokens) {
+const initTokens = (configurationName: string): OidcAccessToken => {
+  const oidc = tryGetOidcClient(configurationName) as OidcClient | null;
+  if (oidc && oidc.tokens) {
     const tokens = oidc.tokens;
     return {
       accessToken: tokens.accessToken,
       accessTokenPayload: tokens.accessTokenPayload,
       generateDemonstrationOfProofOfPossessionAsync: oidc.configuration
-        .demonstrating_proof_of_possession
+        ?.demonstrating_proof_of_possession
         ? (url: string, method: string) =>
             oidc.generateDemonstrationOfProofOfPossessionAsync(tokens.accessToken, url, method)
         : null,
@@ -109,21 +124,23 @@ export type OidcAccessToken = {
 };
 
 function getGenerateDemonstrationOfProofOfPossessionAsync(oidc: OidcClient, tokens: Tokens) {
-  return oidc.configuration.demonstrating_proof_of_possession
+  return oidc.configuration?.demonstrating_proof_of_possession
     ? (url: string, method: string, extras: StringMap = {}) =>
         oidc.generateDemonstrationOfProofOfPossessionAsync(tokens.accessToken, url, method, extras)
     : null;
 }
 
 export const useOidcAccessToken = (configurationName = defaultConfigurationName) => {
-  const getOidc = OidcClient.get;
   const [state, setAccessToken] = useState<OidcAccessToken>(() => initTokens(configurationName));
 
   useEffect(() => {
     let isMounted = true;
-    const oidc = getOidc(configurationName);
+    const oidc = tryGetOidcClient(configurationName) as OidcClient | null;
+    if (!oidc) {
+      return;
+    }
 
-    const newSubscriptionId = oidc.subscribeEvents((name: string, data: any) => {
+    const newSubscriptionId = oidc.subscribeEvents((name: string, _data: any) => {
       if (
         name === OidcClient.eventNames.token_renewed ||
         name === OidcClient.eventNames.token_acquired ||
@@ -157,11 +174,10 @@ export const useOidcAccessToken = (configurationName = defaultConfigurationName)
 
 const idTokenInitialState = { idToken: null, idTokenPayload: null };
 
-const initIdToken = (configurationName: string) => {
-  const getOidc = OidcClient.get;
-  const oidc = getOidc(configurationName);
+const initIdToken = (configurationName: string): OidcIdToken => {
+  const oidc = tryGetOidcClient(configurationName) as OidcClient | null;
 
-  if (oidc.tokens) {
+  if (oidc && oidc.tokens) {
     const tokens = oidc.tokens;
     return { idToken: tokens.idToken, idTokenPayload: tokens.idTokenPayload };
   }
@@ -174,14 +190,16 @@ export type OidcIdToken = {
 };
 
 export const useOidcIdToken = (configurationName = defaultConfigurationName) => {
-  const getOidc = OidcClient.get;
   const [state, setIDToken] = useState<OidcIdToken>(() => initIdToken(configurationName));
 
   useEffect(() => {
     let isMounted = true;
-    const oidc = getOidc(configurationName);
+    const oidc = tryGetOidcClient(configurationName) as OidcClient | null;
+    if (!oidc) {
+      return;
+    }
 
-    const newSubscriptionId = oidc.subscribeEvents((name: string, data: any) => {
+    const newSubscriptionId = oidc.subscribeEvents((name: string, _data: any) => {
       if (
         name === OidcClient.eventNames.token_renewed ||
         name === OidcClient.eventNames.token_acquired ||
@@ -207,3 +225,6 @@ export const useOidcIdToken = (configurationName = defaultConfigurationName) => 
   }, [configurationName]);
   return state;
 };
+
+// Re-exported so callers can use a no-op outside the hooks if needed.
+export const __noopForMissingProvider = noop;

--- a/packages/react-oidc/src/User.ts
+++ b/packages/react-oidc/src/User.ts
@@ -1,6 +1,8 @@
 import { OidcClient, type OidcUserInfo } from '@axa-fr/oidc-client';
 import { useEffect, useRef, useState } from 'react';
 
+import { tryGetOidcClient } from './oidcClientRegistry.js';
+
 export enum OidcUserStatus {
   Unauthenticated = 'Unauthenticated',
   Loading = 'Loading user',
@@ -17,8 +19,8 @@ export const useOidcUser = <T extends OidcUserInfo = OidcUserInfo>(
   configurationName = 'default',
   demonstrating_proof_of_possession = false,
 ) => {
-  const oidc = OidcClient.get(configurationName);
-  const user = oidc.userInfo<T>();
+  const oidc = tryGetOidcClient(configurationName) as OidcClient | null;
+  const user = oidc ? oidc.userInfo<T>() : null;
   const [oidcUser, setOidcUser] = useState<OidcUser<T>>({
     user: user,
     status: user ? OidcUserStatus.Loaded : OidcUserStatus.Unauthenticated,
@@ -27,9 +29,19 @@ export const useOidcUser = <T extends OidcUserInfo = OidcUserInfo>(
   const oidcPreviousUserIdRef = useRef<number>(user ? 1 : 0);
 
   useEffect(() => {
-    const oidc = OidcClient.get(configurationName);
+    const oidc = tryGetOidcClient(configurationName) as OidcClient | null;
     let isMounted = true;
-    if (oidc && oidc.tokens) {
+    if (!oidc) {
+      queueMicrotask(() => {
+        if (isMounted) {
+          setOidcUser({ user: null, status: OidcUserStatus.Unauthenticated });
+        }
+      });
+      return () => {
+        isMounted = false;
+      };
+    }
+    if (oidc.tokens) {
       const isCache = oidcUserId === oidcPreviousUserIdRef.current;
       if (isCache && oidc.userInfo<T>()) {
         return;

--- a/packages/react-oidc/src/index.ts
+++ b/packages/react-oidc/src/index.ts
@@ -1,4 +1,8 @@
 export { useOidcFetch, withOidcFetch } from './FetchToken.js';
+export type { OidcClientLike } from './oidcClientRegistry.js';
+export { registerMockOidcClient, unregisterMockOidcClient } from './oidcClientRegistry.js';
+export type { OidcMockProviderProps, OidcMockTokens, OidcMockValue } from './OidcMockProvider.js';
+export { createMockOidcClient, OidcMockProvider } from './OidcMockProvider.js';
 export type { OidcProviderProps } from './OidcProvider.js';
 export { OidcProvider } from './OidcProvider.js';
 export { OidcSecure, withOidcSecure } from './OidcSecure.js';

--- a/packages/react-oidc/src/oidcClientRegistry.ts
+++ b/packages/react-oidc/src/oidcClientRegistry.ts
@@ -1,0 +1,108 @@
+import { OidcClient } from '@axa-fr/oidc-client';
+
+/**
+ * Minimal duck-typed shape used by the React hooks. Any object that
+ * implements (at least) these members can be supplied as a mock client
+ * through {@link registerMockOidcClient} / {@link OidcMockProvider}.
+ *
+ * The real {@link OidcClient} naturally satisfies this contract, which is
+ * why hooks can treat both the same way.
+ */
+export type OidcClientLike = OidcClient | Record<string, unknown>;
+
+const mockClients = new Map<string, OidcClientLike>();
+const warnedConfigurations = new Set<string>();
+
+/**
+ * Registers a mock OIDC client for the given configuration name.
+ *
+ * Mock clients take precedence over real clients registered via
+ * {@link OidcClient.getOrCreate}, which makes it easy to override the
+ * behavior of the hooks in tests and Storybook stories without touching
+ * the global OIDC database used by {@link OidcProvider}.
+ *
+ * Prefer using the {@link OidcMockProvider} component when possible, which
+ * takes care of registering and unregistering the mock client around the
+ * subtree that needs it.
+ */
+export const registerMockOidcClient = (configurationName: string, client: OidcClientLike): void => {
+  mockClients.set(configurationName, client);
+};
+
+/**
+ * Removes a previously registered mock OIDC client.
+ */
+export const unregisterMockOidcClient = (configurationName: string): void => {
+  mockClients.delete(configurationName);
+};
+
+const isProduction = (): boolean => {
+  try {
+    const proc = (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process;
+    return proc?.env?.NODE_ENV === 'production';
+  } catch {
+    return false;
+  }
+};
+
+const warnMissingProvider = (configurationName: string): void => {
+  if (warnedConfigurations.has(configurationName)) {
+    return;
+  }
+  warnedConfigurations.add(configurationName);
+  if (isProduction()) {
+    return;
+  }
+
+  console.warn(
+    `[react-oidc] No OidcProvider was found for configuration "${configurationName}". ` +
+      'Hooks will return unauthenticated defaults. ' +
+      'This is expected in tests and Storybook. In production, make sure to wrap your ' +
+      'application with <OidcProvider> or use <OidcMockProvider> for mocked rendering.',
+  );
+};
+
+/**
+ * Returns the OIDC client registered for the given configuration name, or
+ * `null` when none is available.
+ *
+ * Lookup order:
+ * 1. A mock client registered via {@link registerMockOidcClient} (or
+ *    {@link OidcMockProvider}).
+ * 2. The real client managed by {@link OidcProvider} (via
+ *    {@link OidcClient.get}).
+ *
+ * Unlike {@link OidcClient.get}, this helper never throws when no client
+ * has been registered – it returns `null` and emits a one-time
+ * development warning. Callers are expected to treat the `null` case as
+ * an unauthenticated state.
+ */
+export const tryGetOidcClient = (configurationName: string): OidcClientLike | null => {
+  const mock = mockClients.get(configurationName);
+  if (mock) {
+    return mock;
+  }
+
+  try {
+    const client = OidcClient.get(configurationName);
+    if (client) {
+      return client;
+    }
+  } catch {
+    // OidcClient.get throws when the library is not initialized for this
+    // configuration. We swallow the error and fall through so the hooks
+    // can render a safe unauthenticated state.
+  }
+
+  warnMissingProvider(configurationName);
+  return null;
+};
+
+/**
+ * Resets the internal "missing provider" warning cache. Intended for use
+ * by unit tests that exercise the warning behavior.
+ */
+export const __resetOidcClientRegistryForTests = (): void => {
+  mockClients.clear();
+  warnedConfigurations.clear();
+};


### PR DESCRIPTION
This PR updates the behavior of useOidc, useOidcUser, and useOidcIdToken so they can be used outside of OidcProvider without throwing, simplifying tests and Storybook stories. It introduces a safer default behavior or mockable context fallback when the provider is absent. Existing usage inside OidcProvider remains fully supported and backward compatible. Additional tests and documentation are added to clarify the new behavior and recommended patterns.

Closes #1679.

Additional context from Copilot / analysis:
Thanks for raising this and for clearly explaining the impact on tests and Storybook – this is a very valid ergonomics issue.

### How things work today

The hooks `useOidc`, `useOidcUser`, `useOidcAccessToken`, and `useOidcIdToken` ultimately depend on an `OidcClient` instance registered by `OidcProvider` (via the configuration name). When no `OidcProvider` has run for the relevant configuration, `OidcClient.get(configurationName)` returns nothing / throws, and the subsequent calls inside the hooks (subscriptions, token access, user info, etc.) fail.

Because this is based on a singleton-style registry rather than React Context that you can override locally, it’s harder to provide clean test/Storybook setups. Existing workarounds indeed tend to either:
- rely on global mutable state, or
- violate rules-of-hooks / linting recommendations.

### Classification of this issue

This is more an evolution / DX improvement than a strict bug: the current behavior is consistent with the library’s design, but it’s unfriendly for testing and Storybook usage. So we’ll treat it as a feature request to:
1. Make the hooks safe when used without a provider, and/or
2. Provide a first-class testing/mocking utility.

### Proposed direction

We see two complementary changes that can be implemented with moderate effort and should be backward compatible for most users:

#### 1. Safe defaults when no provider is registered

When `OidcClient.get(configurationName)` does not find a client, instead of throwing we can:
- Return a stable, unauthenticated default state from each hook.
- Skip any event subscription or network calls.
- Optionally log a development-time warning so misconfiguration in production isn’t silently hidden.

For example (conceptually, not exact typings):

- `useOidc()` could return something like:
  - `isAuthenticated: false`
  - `login: () =&gt; { /* no-op or console.warn in dev */ }`
  - `logout: () =&gt; { /* no-op */ }`
  - `renewTokens: async () =&gt; ({ accessToken: null, accessTokenPayload: null, idToken: null, idTokenPayload: null })`

- `useOidcAccessToken()`:
  - `accessToken: null`
  - `accessTokenPayload: null`
  - `generateDemonstrationOfProofOfPossessionAsync: null` (or a no-op async function)

- `useOidcIdToken()`:
  - `idToken: null`
  - `idTokenPayload: null`

- `useOidcUser()`:
  - `oidcUser: null`
  - `oidcUserLoadingState: OidcUserStatus.Unauthenticated` (or equivalent)
  - `reloadOidcUser: () =&gt; { /* no-op */ }`

Hook effects (`useEffect`) would early-return when the client is missing so that event registrations are not attempted.

This would:
- Stop tests and Storybook stories from throwing when a provider is missing.
- Preserve rules-of-hooks, since the hooks are still always called.
- Semantically match a “logged out / unauthenticated” state.

To avoid masking configuration errors, we can:
- Emit a `console.warn` (only in development) the first time a hook is used without a client for a given configuration.

#### 2. Provide an official mock/test helper

In addition to safer defaults, an official testing utility would make it easy to simulate different auth states. A couple of possible APIs:

- A dedicated React component, for example `OidcMockProvider`, that:
  - On mount, registers a fake `OidcClient` in the same registry used by `OidcProvider`.
  - On unmount, unregisters it.
  - Accepts props like `configurationName`, `isAuthenticated`, `tokens`, `user`, etc.

- Or a functional API, such as `registerMockOidcClient({ configurationName, ... })`, that tests/Storybook can call during setup.

With something like `OidcMockProvider`, usage in tests or Storybook would look like:

```tsx
&lt;OidcMockProvider
  configurationName=&quot;default&quot;
  value={{
    isAuthenticated: true,
    accessToken: &quot;fake-access-token&quot;,
    idToken: &quot;fake-id-token&quot;,
    user: { sub: &quot;123&quot;, name: &quot;Jane Doe&quot; },
  }}
&gt;
  &lt;MyComponent /&gt;
&lt;/OidcMockProvider&gt;
``

The mock client would implement only the subset of methods that the hooks use (e.g. `subscribeEvents`, `removeEventSubscription`, `userInfo/userInfoAsync`, `tokens`, `loginAsync`, `logoutAsync`, `renewTokensAsync`, optional DPoP, etc.). For tests, these can be simple in-memory implementations.

We could expose this from either:
- The main entry point (easiest to discover), or
- A dedicated `@axa-fr/react-oidc/testing` entry for clarity and better tree-shaking.

### Impact and feasibility

- **Scope**: This requires changes in the React hooks layer plus adding a small testing/mocking utility. It’s not a trivial one-liner, but it’s still quite contained.
- **Backward compatibility**: 
  - Some users might currently *rely* on the hooks throwing to detect misconfiguration. For them, the behavior change is observable. To address that, we could:
    - Introduce a “strict mode” flag (e.g. `OidcClient.setStrictMode(true)` or a prop on `OidcProvider`) that preserves the old behavior, or
    - Make the safer behavior opt-in at first (e.g. `enableSafeDefaults` on the provider or via a global config).
- **Security**: Returning unauthenticated/null tokens and a no-op client does not weaken security. The hooks would still never provide any real tokens or authenticated state unless a real client is registered.

### Open questions for you

To ensure we implement this in a way that fits your expectations, it would help to know:

1. **Behavior in production**: Are you comfortable with hooks returning unauthenticated defaults (instead of throwing) in production builds as well? Or would you prefer this safe behavior to be opt-in via a config flag?
2. **Testing API shape**: Would you prefer:
   - A React-based `OidcMockProvider`,
   - Or a function-based `registerMockOidcClient` API,
   - Or both?
3. **Export location**: Would you rather have the testing helper(s):
   - From the main package entry, or
   - From a separate `@axa-fr/react-oidc/testing` entry to signal test-only usage?
4. **Storybook integration**: Would an optional Storybook decorator (e.g. `withOidcMock`) be useful, or is the mock provider itself sufficient for your workflows?

If this direction generally aligns with what you need, we can proceed with a design/PR that:
- Adds safe, unauthenticated defaults for the hooks when no client is registered.
- Emits a dev-time warning in that situation (unless strict mode is enabled).
- Introduces an officially supported mocking/testing utility.

Please let us know your preferences on the above points and any constraints you have (e.g. minimum supported React version, testing framework, or Storybook setup). That will help shape the final API before implementation.
