### PR TITLE
Fix for issue #1678: Provide descriptive error for corrupted or missing OIDC state

### DIFF
--- a/packages/oidc-client/README.md
+++ b/packages/oidc-client/README.md
@@ -434,6 +434,41 @@ pnpm start
 
 ```
 
+## Handling missing or corrupted login state
+
+When the OIDC state or nonce is missing from storage at callback time (for
+example because the user is in a private browsing tab, cleared storage
+manually, or because the browser evicted the entry between the authorize
+redirect and the callback), the library now throws a typed
+`OidcStateError` instead of letting a generic `TypeError` escape.
+
+```ts
+import { isOidcStateError, OidcStateError, OidcStateErrorCode } from '@axa-fr/oidc-client';
+
+try {
+  await oidcClient.loginCallbackAsync();
+} catch (error) {
+  if (isOidcStateError(error)) {
+    switch (error.code) {
+      case OidcStateErrorCode.STATE_MISSING:
+        // The stored state was not found at callback time.
+        break;
+      case OidcStateErrorCode.STATE_MISMATCH:
+        // The state returned by the server does not match the stored one.
+        break;
+      case OidcStateErrorCode.NONCE_MISSING:
+        // The stored nonce was not found at callback time.
+        break;
+    }
+  }
+}
+```
+
+`OidcStateError` is an `Error` subclass, exposes a stable `code` field, and
+is also re-exported from `@axa-fr/react-oidc`. For silent renewal, a missing
+nonce no longer throws a `TypeError` — it is reported through the existing
+`SESSION_LOST` status so consumers can recover via the normal re-login flow.
+
 ## Service worker protocol
 
 The `postMessage` protocol used between `OidcClient` and the service worker

--- a/packages/oidc-client/src/index.ts
+++ b/packages/oidc-client/src/index.ts
@@ -5,6 +5,7 @@ export { OidcLocation } from './location.js';
 export { getFetchDefault } from './oidc.js';
 export type { OidcUserInfo } from './oidcClient.js';
 export { OidcClient } from './oidcClient.js';
+export { isOidcStateError, OidcStateError, OidcStateErrorCode } from './oidcStateError.js';
 export type { Tokens } from './parseTokens.js';
 export { TokenRenewMode } from './parseTokens.js';
 export type {

--- a/packages/oidc-client/src/login.spec.ts
+++ b/packages/oidc-client/src/login.spec.ts
@@ -1,0 +1,151 @@
+// Tests for the guards added to loginCallbackAsync to surface missing /
+// mismatched state and missing nonce as typed `OidcStateError` instead of a
+// generic TypeError. See https://github.com/AxaFrance/oidc-client/issues/1678
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ILOidcLocation } from './location';
+import { loginCallbackAsync } from './login';
+import { OidcStateError, OidcStateErrorCode } from './oidcStateError';
+
+const makeStorage = (): Storage => {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const key of Object.keys(store)) {
+        delete store[key];
+      }
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    [Symbol.iterator]: function* () {
+      yield* Object.entries(store);
+    },
+  } as unknown as Storage;
+};
+
+class FakeLocation implements ILOidcLocation {
+  constructor(private currentHref: string) {}
+  open(): void {}
+  reload(): void {}
+  getCurrentHref(): string {
+    return this.currentHref;
+  }
+  getPath(): string {
+    return '/callback';
+  }
+  getOrigin(): string {
+    return 'http://localhost:4200';
+  }
+}
+
+const buildOidc = ({ href, storage }: { href: string; storage: Storage }) => {
+  const publishedEvents: Array<{ name: string; data: unknown }> = [];
+  const configurationName = 'default';
+  const configuration = {
+    client_id: 'interactive.public.short',
+    redirect_uri: 'http://localhost:4200/authentication/callback',
+    silent_redirect_uri: 'http://localhost:4200/authentication/silent-callback',
+    scope: 'openid profile email',
+    authority: 'http://api',
+    refresh_time_before_tokens_expiration_in_second: 70,
+    token_request_timeout: 30000,
+    authority_configuration: null,
+    storage,
+    login_state_storage: storage,
+    // no service_worker_relative_url -> initWorkerAsync returns null
+  };
+  const oidc: any = {
+    configuration,
+    configurationName,
+    location: new FakeLocation(href),
+    publishEvent: (name: string, data: unknown) => {
+      publishedEvents.push({ name, data });
+    },
+    initAsync: vi.fn(async () => ({
+      issuer: 'http://api',
+      authorizationEndpoint: 'http://api/connect/authorize',
+      tokenEndpoint: 'http://api/connect/token',
+      checkSessionIframe: 'http://api/connect/checksession',
+    })),
+    startCheckSessionAsync: vi.fn(async () => undefined),
+  };
+  return { oidc, publishedEvents };
+};
+
+describe('loginCallbackAsync — state/nonce guards (issue #1678)', () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = makeStorage();
+  });
+
+  it('throws OidcStateError(STATE_MISSING) when stored state is missing but callback URL contains state', async () => {
+    // No `oidc.state.default` written into storage at all (simulates a
+    // private-browsing tab, manual storage clear, or browser eviction
+    // between the authorize redirect and the callback).
+    const href = 'http://localhost:4200/authentication/callback?code=abc&state=server-state-value';
+    const { oidc, publishedEvents } = buildOidc({ href, storage });
+
+    await expect(loginCallbackAsync(oidc)()).rejects.toBeInstanceOf(OidcStateError);
+    await expect(loginCallbackAsync(oidc)()).rejects.toMatchObject({
+      code: OidcStateErrorCode.STATE_MISSING,
+    });
+
+    // The error must also be published as a loginCallbackAsync_error event
+    // so listeners (incl. the React provider) can react to it.
+    const errorEvent = publishedEvents.find(e => e.name === 'loginCallbackAsync_error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent!.data).toBeInstanceOf(OidcStateError);
+  });
+
+  it('throws OidcStateError(STATE_MISMATCH) when the stored state differs from the returned one', async () => {
+    storage[`oidc.state.default`] = 'stored-state-value';
+    storage[`oidc.nonce.default`] = 'stored-nonce-value';
+    const href =
+      'http://localhost:4200/authentication/callback?code=abc&state=different-state-value';
+    const { oidc } = buildOidc({ href, storage });
+
+    await expect(loginCallbackAsync(oidc)()).rejects.toBeInstanceOf(OidcStateError);
+    await expect(loginCallbackAsync(oidc)()).rejects.toMatchObject({
+      code: OidcStateErrorCode.STATE_MISMATCH,
+    });
+  });
+
+  it('throws OidcStateError(NONCE_MISSING) when state is valid but nonce is missing from storage', async () => {
+    storage[`oidc.state.default`] = 'matching-state';
+    // No oidc.nonce.default written -> getNonceAsync returns { nonce: undefined }
+    const href = 'http://localhost:4200/authentication/callback?code=abc&state=matching-state';
+    const { oidc } = buildOidc({ href, storage });
+
+    await expect(loginCallbackAsync(oidc)()).rejects.toBeInstanceOf(OidcStateError);
+    await expect(loginCallbackAsync(oidc)()).rejects.toMatchObject({
+      code: OidcStateErrorCode.NONCE_MISSING,
+    });
+  });
+
+  it('does not throw a generic TypeError when state and nonce are both missing', async () => {
+    // Regression: before the fix, a missing nonce would surface as
+    // "Cannot read properties of undefined (reading 'nonce')" when reaching
+    // isTokensOidcValid(..., nonceData.nonce, ...).
+    const href = 'http://localhost:4200/authentication/callback?code=abc&state=server-state-value';
+    const { oidc } = buildOidc({ href, storage });
+
+    let caught: unknown;
+    try {
+      await loginCallbackAsync(oidc)();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(OidcStateError);
+    expect(caught).not.toBeInstanceOf(TypeError);
+  });
+});

--- a/packages/oidc-client/src/login.ts
+++ b/packages/oidc-client/src/login.ts
@@ -5,6 +5,7 @@ import { initWorkerAsync } from './initWorker.js';
 import { generateJwkAsync, generateJwtDemonstratingProofOfPossessionAsync } from './jwt';
 import { ILOidcLocation } from './location';
 import Oidc from './oidc';
+import { OidcStateError, OidcStateErrorCode } from './oidcStateError.js';
 import { isTokensOidcValid } from './parseTokens.js';
 import { performAuthorizationRequestAsync, performFirstTokenRequestAsync } from './requests.js';
 import { getParseQueryStringFromLocation } from './route-utils.js';
@@ -156,8 +157,28 @@ export const loginCallbackAsync =
           `Issuer not valid (expected: ${oidcServerConfiguration.issuer}, received: ${queryParams.iss})`,
         );
       }
-      if (queryParams.state && queryParams.state !== state) {
-        throw new Error(`State not valid (expected: ${state}, received: ${queryParams.state})`);
+      // Surface missing / mismatched login state as a typed, identifiable error
+      // rather than a generic TypeError when later dereferencing nonceData.nonce.
+      // See https://github.com/AxaFrance/oidc-client/issues/1678
+      if (queryParams.state) {
+        if (!state) {
+          throw new OidcStateError(
+            OidcStateErrorCode.STATE_MISSING,
+            'OIDC state is missing from storage. The login state may have been cleared between the authorization redirect and the callback (e.g., private browsing, storage cleared, or browser eviction).',
+          );
+        }
+        if (queryParams.state !== state) {
+          throw new OidcStateError(
+            OidcStateErrorCode.STATE_MISMATCH,
+            `OIDC state does not match the stored one (expected: ${state}, received: ${queryParams.state}).`,
+          );
+        }
+      }
+      if (!nonceData || !nonceData.nonce) {
+        throw new OidcStateError(
+          OidcStateErrorCode.NONCE_MISSING,
+          'OIDC nonce is missing from storage. The login state may have been cleared between the authorization redirect and the callback (e.g., private browsing, storage cleared, or browser eviction).',
+        );
       }
 
       const data = {

--- a/packages/oidc-client/src/oidcStateError.spec.ts
+++ b/packages/oidc-client/src/oidcStateError.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { isOidcStateError, OidcStateError, OidcStateErrorCode } from './oidcStateError';
+
+describe('OidcStateError', () => {
+  it('exposes the well-known state error codes', () => {
+    expect(OidcStateErrorCode.STATE_MISSING).toBe('STATE_MISSING');
+    expect(OidcStateErrorCode.STATE_MISMATCH).toBe('STATE_MISMATCH');
+    expect(OidcStateErrorCode.NONCE_MISSING).toBe('NONCE_MISSING');
+  });
+
+  it('is an Error subclass with name "OidcStateError"', () => {
+    const err = new OidcStateError(OidcStateErrorCode.STATE_MISSING, 'missing');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(OidcStateError);
+    expect(err.name).toBe('OidcStateError');
+  });
+
+  it('preserves the code and message passed to the constructor', () => {
+    const err = new OidcStateError(OidcStateErrorCode.STATE_MISMATCH, 'mismatch happened');
+    expect(err.code).toBe('STATE_MISMATCH');
+    expect(err.message).toBe('mismatch happened');
+  });
+
+  it('is detectable via isOidcStateError', () => {
+    const err = new OidcStateError(OidcStateErrorCode.NONCE_MISSING, 'nonce missing');
+    expect(isOidcStateError(err)).toBe(true);
+    expect(isOidcStateError(new Error('boom'))).toBe(false);
+    expect(isOidcStateError(null)).toBe(false);
+    expect(isOidcStateError(undefined)).toBe(false);
+    expect(isOidcStateError({ code: 'STATE_MISSING' })).toBe(false);
+  });
+});

--- a/packages/oidc-client/src/oidcStateError.ts
+++ b/packages/oidc-client/src/oidcStateError.ts
@@ -1,0 +1,50 @@
+/**
+ * Stable, machine-readable codes for OIDC state / nonce failures occurring
+ * between the authorization redirect and the callback handling.
+ *
+ * These codes let consumers react to specific failure modes without having to
+ * pattern-match against error message strings.
+ */
+export const OidcStateErrorCode = {
+  /** No state was found in storage when handling the callback. */
+  STATE_MISSING: 'STATE_MISSING',
+  /** The state returned by the server does not match the stored one. */
+  STATE_MISMATCH: 'STATE_MISMATCH',
+  /** No nonce was found in storage when handling the callback / renewal. */
+  NONCE_MISSING: 'NONCE_MISSING',
+} as const;
+
+// Companion type that mirrors the const above. This is the standard TS
+// "string-enum-like" pattern; we intentionally reuse the same name so that
+// `OidcStateErrorCode` works as both a value namespace and a type for
+// consumers.
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type OidcStateErrorCode = (typeof OidcStateErrorCode)[keyof typeof OidcStateErrorCode];
+
+/**
+ * Typed error thrown when the OIDC login state or nonce is missing,
+ * corrupted, or does not match the value returned by the authorization server.
+ *
+ * Consumers can use `instanceof OidcStateError` and inspect `code` instead of
+ * relying on the (unstable) error message text.
+ */
+export class OidcStateError extends Error {
+  readonly code: OidcStateErrorCode;
+
+  constructor(code: OidcStateErrorCode, message: string) {
+    super(message);
+    this.name = 'OidcStateError';
+    this.code = code;
+
+    // Keep prototype chain intact when transpiled to ES5.
+    Object.setPrototypeOf(this, OidcStateError.prototype);
+  }
+}
+
+/**
+ * Type guard for {@link OidcStateError}. Useful in callers that want to react
+ * specifically to state/nonce failures.
+ */
+export const isOidcStateError = (value: unknown): value is OidcStateError => {
+  return value instanceof OidcStateError;
+};

--- a/packages/oidc-client/src/renewTokens.ts
+++ b/packages/oidc-client/src/renewTokens.ts
@@ -446,6 +446,19 @@ const synchroniseTokensAsync =
             );
 
             if (tokenResponse.success) {
+              // Guard against a missing/corrupted nonce reaching id_token validation.
+              // Without this guard, accessing `nonce.nonce` would throw a TypeError
+              // when the underlying storage has been cleared (private mode, manual
+              // clearing, browser eviction). We prefer a defined SESSION_LOST result
+              // so silent renew stays non-throwing for consumers.
+              // See https://github.com/AxaFrance/oidc-client/issues/1678
+              if (!nonce || !nonce.nonce) {
+                updateTokens(null);
+                oidc.publishEvent(eventNames.refreshTokensAsync_error, {
+                  message: 'refresh token: nonce missing from storage',
+                });
+                return { tokens: null, status: 'SESSION_LOST' };
+              }
               const { isValid, reason } = isTokensOidcValid(
                 tokenResponse.data,
                 nonce.nonce,

--- a/packages/react-oidc/src/index.ts
+++ b/packages/react-oidc/src/index.ts
@@ -13,8 +13,11 @@ export type {
 } from '@axa-fr/oidc-client';
 export type { OidcUserInfo } from '@axa-fr/oidc-client';
 export {
+  isOidcStateError,
   OidcClient,
   OidcLocation,
+  OidcStateError,
+  OidcStateErrorCode,
   TokenAutomaticRenewMode,
   TokenRenewMode,
 } from '@axa-fr/oidc-client';


### PR DESCRIPTION
This PR updates the OIDC state handling logic to detect corrupted or missing state and surface a clear, descriptive error instead of a generic TypeError. It adds validation and defensive checks around state parsing and retrieval. The change also includes improved error messaging to help developers diagnose misconfigurations or unexpected state loss. Where possible, existing behavior is preserved while failing more gracefully in error scenarios.

Closes #1678.

Additional context from Copilot / analysis:
Thanks for the detailed analysis and for calling out the specific code paths and the brittle nature of the current workaround.

You’re absolutely right: when the OIDC state/nonce is missing, stale, or corrupted, we should surface a clear, typed, and recoverable error instead of letting a generic `TypeError` escape from dereferencing `nonce`/`nonceData`. That’s a genuine bug in terms of error handling and developer experience.

### What’s happening today

From your description (and the paths you referenced):

- In `packages/oidc-client/src/login.ts` (around where `session.getNonceAsync()` / `getStateAsync()` are called and later `nonceData.nonce` is used), and
- In `packages/oidc-client/src/renewTokens.ts` (where `nonce = await ...getNonceAsync()` and later `nonce.nonce` is read),

we currently assume state/nonce are present. When the underlying storage has been cleared or corrupted between redirect and callback (e.g., private browsing, user manually clearing storage, another tab touching it, or browser eviction), that assumption breaks and we end up with:

- `nonceData` or `nonce` being `undefined` or missing its `nonce` field,
- which then results in a `TypeError` when accessing `.nonce`, instead of a descriptive “state/nonce missing or invalid” error that applications can react to.

The existing guard in `login.ts` that checks `queryParams.state` against the stored state only catches the **mismatch** case when both sides exist. If the stored state/nonce are missing entirely, we skip that guard and go straight to the unsafe dereference, which aligns with your observation.

### Classification

- **Type of issue**: Bug (unhandled missing state/nonce leading to an opaque runtime error)
- **Complexity**: The fix is localized (guards + error typing) but touches a couple of code paths and possibly the React wrapper, so it’s still conceptually simple.
- **Security**: This is related to authentication state handling and token validation, so we should treat it as security-sensitive even though the bug itself is about error reporting rather than a direct vulnerability.

### Direction for a fix

Your proposed solution direction makes sense overall. Concretely, we should:

1. **Introduce a typed, identifiable error for state/nonce problems**
   - Add an `OidcStateError` (or similar) class with structured codes like `STATE_MISSING`, `STATE_MISMATCH`, `NONCE_MISSING`.
   - Re-export it from the main entry point so consumers can:
     - `instanceof OidcStateError`, and
     - inspect a `code` field instead of parsing error message text.

2. **Add explicit guards in the login callback path**
   - After we read state/nonce from storage (session, service worker, etc.), we should:
     - Throw `OidcStateError` with `STATE_MISSING` if there is no stored state.
     - Throw `OidcStateError` with `NONCE_MISSING` if state exists but nonce is absent.
     - Convert the existing “state not valid” error into `OidcStateError` with `STATE_MISMATCH` so all state-related failures are uniform and typed.
   - This ensures that any missing or invalid state surfaces as a clear, predictable error instead of a `TypeError`.

3. **Add corresponding guards in the token renewal path**
   - Before any `isTokensOidcValid(..., nonce.nonce, ...)` call, validate that `nonce` and `nonce.nonce` exist.
   - For silent refresh, we should be careful not to introduce unnecessary breaking changes. Two reasonable options:
     - Return a well-defined “session lost” outcome (if that’s already part of the API), or
     - Throw `OidcStateError` with `STATE_MISSING`/`NONCE_MISSING` and document that behavior for consumers.
   - Given existing behavior, returning a “session lost” / “cannot renew because state is gone” result may be the safer, non-breaking default.

4. **React integration (`@axa-fr/react-oidc`)**
   - Emitting dedicated events or callbacks such as `onStateMissing` / `onStateMismatch` (or a generic state-error callback with a `code`) is a good idea.
   - This lets React applications:
     - Show a dedicated UX (“We can’t complete your login because your session information disappeared. Please try again.”),
     - Avoid relying on substring matching of error messages,
     - Handle different cases (missing vs mismatch vs normal session lost) explicitly.

5. **Tests**
   - We should add tests that simulate:
     - Callback where `code` and `state` are present in the URL but the stored state is missing → `OidcStateError(STATE_MISSING)`.
     - Callback where `state` is present but doesn’t match the stored one → `OidcStateError(STATE_MISMATCH)`.
     - Callback where state exists but nonce is missing → `OidcStateError(NONCE_MISSING)`.
     - Token renewal where nonce is missing → predictable “session lost” or a defined `OidcStateError`, depending on the chosen API.

### Next steps / Questions

Before finalizing an implementation, we’d like to clarify with you:

1. **Renewal behavior**: In your use case, would you prefer silent renew to:
   - Return a “session lost” result (non-throwing, for smoother UX), or
   - Throw a typed `OidcStateError`, making it consistent with the login callback path but requiring explicit error handling?

2. **Exact stack trace**: If possible, could you share the full stack trace of the `TypeError` you’re seeing (with versions of `oidc-client` and `@axa-fr/react-oidc`)? That helps us ensure our tests and guards line up exactly with the failing path you hit.

3. **Which storage backend**: Are you using the service worker–based storage or the standard storage? Both are relevant, but knowing which one you’re using will help prioritize test coverage and ensure we don’t miss the variant you’re actually hitting.

Once we have your preferences on silent renew behavior and a bit more detail on the exact call site, we can either:

- Implement the changes directly, or
- Review and integrate a PR if you’d like to contribute it (your proposed approach is aligned with what we’d expect).

Either way, the goal is exactly what you described: to replace brittle substring-based error detection with explicit, typed errors and dedicated React hooks/callbacks so this failure mode is both understandable and easily recoverable at the application level.
