### PR TITLE
Fix for issue #1677: Prevent logoutAsync session clearing race before navigation

### DIFF
--- a/packages/oidc-client/src/logout.spec.ts
+++ b/packages/oidc-client/src/logout.spec.ts
@@ -2,8 +2,9 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
+import { eventNames } from './events';
 import { ILOidcLocation } from './location';
-import { logoutAsync } from './logout';
+import { clearSessionAsync, logoutAsync } from './logout';
 
 describe('Logout test suite', () => {
   const expectedFinalUrl =
@@ -138,4 +139,210 @@ describe('Logout test suite', () => {
       expect(finalUrl).toBe(expectedFinalUrl);
     },
   );
+
+  it('navigates to end_session_endpoint before clearing the local session (issue #1677)', async () => {
+    // This is the regression test for the race described in issue #1677.
+    // `OidcProvider`/`OidcSecure` watches `oidc.tokens`; if `destroyAsync`
+    // runs before `oicLocation.open`, the React tree can briefly observe a
+    // null token state and kick off a new auth flow before the navigation
+    // to the IdP's end-session endpoint commits.
+    const configuration = {
+      client_id: 'interactive.public.short',
+      authority: 'http://api',
+      logout_tokens_to_invalidate: ['access_token', 'refresh_token'],
+    };
+
+    const callOrder: string[] = [];
+
+    const mockFetchFn = vi.fn().mockImplementation(() => {
+      callOrder.push('revoke');
+      return Promise.resolve({ status: 200 });
+    });
+
+    const oidc: any = {
+      configuration,
+      tokens: {
+        idToken: 'abcd',
+        accessToken: 'abcd',
+        refreshToken: 'abdc',
+        idTokenPayload: { sub: 'sub-123' },
+      },
+      isLoggingOut: false,
+      initAsync: () =>
+        Promise.resolve({
+          revocationEndpoint: 'http://api/connect/revocation',
+          endSessionEndpoint: 'http://api/connect/endsession',
+        }),
+      destroyAsync: vi.fn().mockImplementation(() => {
+        callOrder.push('destroyAsync');
+        oidc.tokens = null;
+        return Promise.resolve();
+      }),
+      logoutSameTabAsync: () => Promise.resolve(),
+      publishEvent: (name: string) => callOrder.push(`publishEvent:${name}`),
+    };
+
+    const oidcDatabase = { default: oidc };
+
+    let navigatedUrl = '';
+    class OidcLocationMock implements ILOidcLocation {
+      open(url: string): void {
+        callOrder.push('open');
+        navigatedUrl = url;
+      }
+      getCurrentHref() {
+        return '';
+      }
+      getPath() {
+        return '';
+      }
+      reload() {
+        callOrder.push('reload');
+      }
+      getOrigin() {
+        return 'http://localhost:4200';
+      }
+    }
+
+    await logoutAsync(
+      oidc,
+      oidcDatabase,
+      mockFetchFn,
+      console,
+      new OidcLocationMock(),
+    )('/logged_out', null);
+
+    // Revocation comes first (so tokens are still valid when revoked),
+    // navigation comes second (page starts unloading), and only then we
+    // clear local state and broadcast `logout_from_same_tab`.
+    expect(callOrder[0]).toBe('revoke');
+    expect(callOrder[1]).toBe('revoke');
+    expect(callOrder[2]).toBe('open');
+    expect(callOrder.indexOf('destroyAsync')).toBeGreaterThan(callOrder.indexOf('open'));
+    expect(callOrder.indexOf(`publishEvent:${eventNames.logout_from_same_tab}`)).toBeGreaterThan(
+      callOrder.indexOf('open'),
+    );
+
+    // The id_token_hint must still be present on the navigation URL, even
+    // though local tokens have been cleared by `destroyAsync` afterwards.
+    expect(navigatedUrl).toContain('id_token_hint=abcd');
+    expect(navigatedUrl).toContain(
+      'post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A4200%2Flogged_out',
+    );
+
+    // The flag stays set after the call returns: the page is expected to be
+    // unloading and any UI re-render that briefly observes `tokens === null`
+    // should skip starting a new login flow.
+    expect(oidc.isLoggingOut).toBe(true);
+  });
+
+  it('resets isLoggingOut and does not navigate when no_reload is requested', async () => {
+    const configuration = {
+      client_id: 'interactive.public.short',
+      authority: 'http://api',
+      logout_tokens_to_invalidate: [],
+    };
+
+    const events: string[] = [];
+    let navigated = false;
+    const oidc: any = {
+      configuration,
+      tokens: {
+        idToken: 'abcd',
+        accessToken: 'abcd',
+        refreshToken: 'abdc',
+        idTokenPayload: { sub: 'sub-123' },
+      },
+      isLoggingOut: false,
+      initAsync: () =>
+        Promise.resolve({
+          revocationEndpoint: 'http://api/connect/revocation',
+          endSessionEndpoint: 'http://api/connect/endsession',
+        }),
+      destroyAsync: () => Promise.resolve(),
+      logoutSameTabAsync: () => Promise.resolve(),
+      publishEvent: (name: string) => events.push(name),
+    };
+    const oidcDatabase = { default: oidc };
+
+    class OidcLocationMock implements ILOidcLocation {
+      open() {
+        navigated = true;
+      }
+      getCurrentHref() {
+        return '';
+      }
+      getPath() {
+        return '';
+      }
+      reload() {
+        navigated = true;
+      }
+      getOrigin() {
+        return 'http://localhost:4200';
+      }
+    }
+
+    await logoutAsync(
+      oidc,
+      oidcDatabase,
+      vi.fn(),
+      console,
+      new OidcLocationMock(),
+    )('/logged_out', { 'no_reload:oidc': 'true' });
+
+    expect(navigated).toBe(false);
+    expect(events).toContain(eventNames.logout_from_same_tab);
+    expect(oidc.isLoggingOut).toBe(false);
+  });
+
+  describe('clearSessionAsync', () => {
+    it('clears the local session and emits logout_from_same_tab without contacting the IdP', async () => {
+      const events: { name: string; data: unknown }[] = [];
+      const oidc: any = {
+        configuration: { client_id: 'interactive.public.short' },
+        tokens: {
+          idToken: 'abcd',
+          accessToken: 'abcd',
+          refreshToken: 'abdc',
+          idTokenPayload: { sub: 'sub-123' },
+        },
+        destroyAsync: vi.fn().mockImplementation(status => {
+          oidc.tokens = null;
+          events.push({ name: 'destroyAsync', data: status });
+          return Promise.resolve();
+        }),
+        logoutSameTabAsync: vi.fn().mockResolvedValue(undefined),
+        publishEvent: (name: string, data: unknown) => events.push({ name, data }),
+      };
+      const oidcDatabase = { default: oidc };
+
+      await clearSessionAsync(oidc, oidcDatabase)();
+
+      expect(oidc.destroyAsync).toHaveBeenCalledWith('LOGGED_OUT');
+      expect(oidc.tokens).toBeNull();
+      expect(events.some(e => e.name === eventNames.logout_from_same_tab)).toBe(true);
+    });
+
+    it('calls logoutSameTabAsync for sibling OIDC clients registered in the same tab', async () => {
+      const oidc: any = {
+        configuration: { client_id: 'interactive.public.short' },
+        tokens: {
+          idToken: 'abcd',
+          accessToken: 'abcd',
+          refreshToken: 'abdc',
+          idTokenPayload: { sub: 'sub-123' },
+        },
+        destroyAsync: () => Promise.resolve(),
+        logoutSameTabAsync: vi.fn().mockResolvedValue(undefined),
+        publishEvent: () => undefined,
+      };
+      const sibling: any = { configuration: { client_id: 'other' } };
+      const oidcDatabase = { default: oidc, other: sibling };
+
+      await clearSessionAsync(oidc, oidcDatabase)();
+
+      expect(oidc.logoutSameTabAsync).toHaveBeenCalledWith('interactive.public.short', 'sub-123');
+    });
+  });
 });

--- a/packages/oidc-client/src/logout.ts
+++ b/packages/oidc-client/src/logout.ts
@@ -59,6 +59,58 @@ export const destroyAsync = oidc => async status => {
   oidc.userInfo = null;
 };
 
+/**
+ * Clears the local OIDC session (tokens, user info, service-worker storage)
+ * and broadcasts `logout_from_same_tab` to any other OIDC clients registered
+ * in the same tab.
+ *
+ * It is intentionally decoupled from `logoutAsync`: callers that want to drop
+ * the local session without contacting the identity provider — for example a
+ * service-worker-only flow, a SPA-only logout, or an error-recovery path —
+ * can use this helper directly. `logoutAsync` itself calls it as the very
+ * last step, after the browser navigation to `end_session_endpoint` has been
+ * scheduled, so that the React tree never observes a transient "no tokens"
+ * state before the page is unloaded.
+ */
+export const clearSessionAsync = (oidc, oidcDatabase) => async () => {
+  const sub = oidc.tokens?.idTokenPayload?.sub ?? null;
+  await oidc.destroyAsync('LOGGED_OUT');
+  for (const [, itemOidc] of Object.entries(oidcDatabase)) {
+    if (itemOidc !== oidc) {
+      // @ts-ignore
+      await oidc.logoutSameTabAsync(oidc.configuration.client_id, sub);
+    } else {
+      oidc.publishEvent(eventNames.logout_from_same_tab, {});
+    }
+  }
+};
+
+const buildEndSessionUrl = (
+  endSessionEndpoint: string,
+  endPointExtras: StringMap,
+  idToken: string,
+  postLogoutRedirectUri: string | null,
+): string => {
+  if (!('id_token_hint' in endPointExtras)) {
+    endPointExtras['id_token_hint'] = idToken;
+  }
+  if (!('post_logout_redirect_uri' in endPointExtras) && postLogoutRedirectUri !== null) {
+    endPointExtras['post_logout_redirect_uri'] = postLogoutRedirectUri;
+  }
+  let queryString = '';
+  for (const [key, value] of Object.entries(endPointExtras)) {
+    if (value !== null && value !== undefined) {
+      if (queryString === '') {
+        queryString += '?';
+      } else {
+        queryString += '&';
+      }
+      queryString += `${key}=${encodeURIComponent(value)}`;
+    }
+  }
+  return `${endSessionEndpoint}${queryString}`;
+};
+
 export const logoutAsync =
   (oidc, oidcDatabase, fetch, console, oicLocation: ILOidcLocation) =>
   async (callbackPathOrUrl: string | null | undefined = undefined, extras: StringMap = null) => {
@@ -79,94 +131,111 @@ export const logoutAsync =
     if (callbackPathOrUrl) {
       isUri = callbackPathOrUrl.includes('https://') || callbackPathOrUrl.includes('http://');
     }
-    const url = isUri ? callbackPathOrUrl : oicLocation.getOrigin() + path;
+    const postLogoutRedirectUri =
+      callbackPathOrUrl === null
+        ? null
+        : isUri
+          ? callbackPathOrUrl
+          : oicLocation.getOrigin() + path;
+    // Capture identifiers from the live session *before* any clear happens, so the
+    // values stay valid no matter when we drop local state.
     // @ts-ignore
     const idToken = oidc.tokens ? oidc.tokens.idToken : '';
+
+    // Mark the instance as "logout in progress" so consumers (OidcSecure, route
+    // guards, silent renew, 401 retry interceptors, …) can back off from
+    // triggering a new auth flow during the window between us clearing the
+    // local session and the browser actually navigating away.
+    oidc.isLoggingOut = true;
+
     try {
-      const revocationEndpoint = oidcServerConfiguration.revocationEndpoint;
-      if (revocationEndpoint) {
-        const promises = [];
-        const accessToken = oidc.tokens ? oidc.tokens.accessToken : null;
-        if (
-          accessToken &&
-          configuration.logout_tokens_to_invalidate.includes(oidcLogoutTokens.access_token)
-        ) {
-          const revokeAccessTokenExtras = extractExtras(extras, ':revoke_access_token');
-          const revokeAccessTokenPromise = performRevocationRequestAsync(fetch)(
-            revocationEndpoint,
-            accessToken,
-            TOKEN_TYPE.access_token,
-            configuration.client_id,
-            revokeAccessTokenExtras,
-          );
-          promises.push(revokeAccessTokenPromise);
-        }
-        const refreshToken = oidc.tokens ? oidc.tokens.refreshToken : null;
-        if (
-          refreshToken &&
-          configuration.logout_tokens_to_invalidate.includes(oidcLogoutTokens.refresh_token)
-        ) {
-          const revokeAccessTokenExtras = extractExtras(extras, ':revoke_refresh_token');
-          const revokeRefreshTokenPromise = performRevocationRequestAsync(fetch)(
-            revocationEndpoint,
-            refreshToken,
-            TOKEN_TYPE.refresh_token,
-            configuration.client_id,
-            revokeAccessTokenExtras,
-          );
-          promises.push(revokeRefreshTokenPromise);
-        }
-        if (promises.length > 0) {
-          await Promise.all(promises);
-        }
-      }
-    } catch (exception) {
-      console.warn(
-        'logoutAsync: error when revoking tokens, if the error persist, you ay configure property logout_tokens_to_invalidate from configuration to avoid this error',
-      );
-      console.warn(exception);
-    }
-    const sub = oidc.tokens?.idTokenPayload?.sub ?? null;
-
-    await oidc.destroyAsync('LOGGED_OUT');
-    for (const [, itemOidc] of Object.entries(oidcDatabase)) {
-      if (itemOidc !== oidc) {
-        // @ts-ignore
-        await oidc.logoutSameTabAsync(oidc.configuration.client_id, sub);
-      } else {
-        oidc.publishEvent(eventNames.logout_from_same_tab, {});
-      }
-    }
-
-    const oidcExtras = extractExtras(extras, ':oidc');
-    const noReload = oidcExtras && oidcExtras['no_reload'] === 'true';
-
-    if (noReload) {
-      return;
-    }
-
-    const endPointExtras = keepExtras(extras);
-
-    if (oidcServerConfiguration.endSessionEndpoint) {
-      if (!('id_token_hint' in endPointExtras)) {
-        endPointExtras['id_token_hint'] = idToken;
-      }
-      if (!('post_logout_redirect_uri' in endPointExtras) && callbackPathOrUrl !== null) {
-        endPointExtras['post_logout_redirect_uri'] = url;
-      }
-      let queryString = '';
-      for (const [key, value] of Object.entries(endPointExtras)) {
-        if (value !== null && value !== undefined) {
-          if (queryString === '') {
-            queryString += '?';
-          } else {
-            queryString += '&';
+      try {
+        const revocationEndpoint = oidcServerConfiguration.revocationEndpoint;
+        if (revocationEndpoint) {
+          const promises = [];
+          const accessToken = oidc.tokens ? oidc.tokens.accessToken : null;
+          if (
+            accessToken &&
+            configuration.logout_tokens_to_invalidate.includes(oidcLogoutTokens.access_token)
+          ) {
+            const revokeAccessTokenExtras = extractExtras(extras, ':revoke_access_token');
+            const revokeAccessTokenPromise = performRevocationRequestAsync(fetch)(
+              revocationEndpoint,
+              accessToken,
+              TOKEN_TYPE.access_token,
+              configuration.client_id,
+              revokeAccessTokenExtras,
+            );
+            promises.push(revokeAccessTokenPromise);
           }
-          queryString += `${key}=${encodeURIComponent(value)}`;
+          const refreshToken = oidc.tokens ? oidc.tokens.refreshToken : null;
+          if (
+            refreshToken &&
+            configuration.logout_tokens_to_invalidate.includes(oidcLogoutTokens.refresh_token)
+          ) {
+            const revokeAccessTokenExtras = extractExtras(extras, ':revoke_refresh_token');
+            const revokeRefreshTokenPromise = performRevocationRequestAsync(fetch)(
+              revocationEndpoint,
+              refreshToken,
+              TOKEN_TYPE.refresh_token,
+              configuration.client_id,
+              revokeAccessTokenExtras,
+            );
+            promises.push(revokeRefreshTokenPromise);
+          }
+          if (promises.length > 0) {
+            // Revocation must be awaited *before* navigation, so a cancelled
+            // navigation can never leave valid tokens behind both in storage
+            // and on the authorization server.
+            await Promise.all(promises);
+          }
         }
+      } catch (exception) {
+        console.warn(
+          'logoutAsync: error when revoking tokens, if the error persist, you ay configure property logout_tokens_to_invalidate from configuration to avoid this error',
+        );
+        console.warn(exception);
       }
-      oicLocation.open(`${oidcServerConfiguration.endSessionEndpoint}${queryString}`);
-    } else {
-      oicLocation.reload();
+
+      const oidcExtras = extractExtras(extras, ':oidc');
+      const noReload = oidcExtras && oidcExtras['no_reload'] === 'true';
+
+      if (noReload) {
+        // No navigation happens here: this branch is essentially a "clear local
+        // session" call dressed as a logout. We can drop state immediately and
+        // reset the flag since the call returns normally to the caller.
+        await clearSessionAsync(oidc, oidcDatabase)();
+        oidc.isLoggingOut = false;
+        return;
+      }
+
+      // Navigate to the end-session endpoint (or reload) *before* clearing the
+      // local session. This closes the race where `OidcProvider` /
+      // `OidcSecure` / silent-renew timers observe a null `tokens` and kick
+      // off a new auth flow in the window between local clear and navigation.
+      const endPointExtras = keepExtras(extras);
+      if (oidcServerConfiguration.endSessionEndpoint) {
+        const endSessionUrl = buildEndSessionUrl(
+          oidcServerConfiguration.endSessionEndpoint,
+          endPointExtras,
+          idToken,
+          postLogoutRedirectUri,
+        );
+        oicLocation.open(endSessionUrl);
+      } else {
+        oicLocation.reload();
+      }
+
+      // Now that navigation has been scheduled, drop the local session. By the
+      // time React re-renders against the null tokens the page is already
+      // unloading; if for any reason it is not (e.g. navigation cancelled by a
+      // `beforeunload` handler) the `isLoggingOut` flag stays set so guards
+      // still know not to start a fresh auth flow.
+      await clearSessionAsync(oidc, oidcDatabase)();
+    } catch (exception) {
+      // If anything went wrong, reset the flag so the app is not stuck in a
+      // "logging out forever" state.
+      oidc.isLoggingOut = false;
+      throw exception;
     }
   };

--- a/packages/oidc-client/src/oidc.ts
+++ b/packages/oidc-client/src/oidc.ts
@@ -12,7 +12,7 @@ import {
 import { tryKeepSessionAsync } from './keepSession';
 import { ILOidcLocation, OidcLocation } from './location';
 import { defaultLoginAsync, loginCallbackAsync } from './login.js';
-import { destroyAsync, logoutAsync } from './logout.js';
+import { clearSessionAsync, destroyAsync, logoutAsync } from './logout.js';
 import { TokenRenewMode, Tokens } from './parseTokens.js';
 import { autoRenewTokens, renewTokensAndStartTimerAsync } from './renewTokens.js';
 import { fetchFromIssuer } from './requests.js';
@@ -99,6 +99,14 @@ export class Oidc {
   public checkSessionIFrame: CheckSessionIFrame;
   public getFetch: () => Fetch;
   public location: ILOidcLocation;
+  /**
+   * `true` while {@link logoutAsync} is executing or has scheduled a
+   * navigation to the identity provider's end-session endpoint that has not
+   * yet committed. Consumers (UI guards, silent-renew handlers, 401 retry
+   * interceptors, …) should check this flag and skip starting a new auth
+   * flow when it is set, even if `tokens` is null.
+   */
+  public isLoggingOut = false;
   constructor(
     configuration: OidcConfiguration,
     configurationName = 'default',
@@ -450,6 +458,27 @@ Please checkout that you are using OIDC hook inside a <OidcProvider configuratio
 
   async destroyAsync(status) {
     return await destroyAsync(this)(status);
+  }
+
+  /**
+   * Drops the local OIDC session (tokens, user info, service-worker storage)
+   * and broadcasts `logout_from_same_tab`, without contacting the identity
+   * provider's `end_session_endpoint` and without revoking tokens.
+   *
+   * Use this for SPA-only logouts, service-worker-only flows, or
+   * error-recovery paths where a full IdP logout is not needed or not
+   * desirable. For a standard OIDC RP-initiated logout use
+   * {@link logoutAsync} instead.
+   */
+  clearSessionPromise: Promise<void> = null;
+  async clearSessionAsync(): Promise<void> {
+    if (this.clearSessionPromise) {
+      return this.clearSessionPromise;
+    }
+    this.clearSessionPromise = clearSessionAsync(this, oidcDatabase)();
+    return this.clearSessionPromise.finally(() => {
+      this.clearSessionPromise = null;
+    });
   }
 
   async logoutSameTabAsync(clientId: string, sub: any) {

--- a/packages/oidc-client/src/oidcClient.ts
+++ b/packages/oidc-client/src/oidcClient.ts
@@ -64,6 +64,32 @@ export class OidcClient {
     return this._oidc.logoutAsync(callbackPathOrUrl, extras);
   }
 
+  /**
+   * Drops the local OIDC session (tokens, user info, service-worker storage)
+   * and notifies same-tab listeners via the `logout_from_same_tab` event,
+   * without contacting the identity provider's `end_session_endpoint` and
+   * without revoking tokens.
+   *
+   * Use this for SPA-only logouts, service-worker-only flows, or
+   * error-recovery paths. For a standard OIDC RP-initiated logout (with
+   * token revocation and navigation to the IdP's end-session endpoint) use
+   * {@link logoutAsync} instead.
+   */
+  clearSessionAsync(): Promise<void> {
+    return this._oidc.clearSessionAsync();
+  }
+
+  /**
+   * `true` while a logout flow is in progress: between the moment
+   * {@link logoutAsync} starts and the moment the browser navigates away to
+   * the identity provider's end-session endpoint. UI guards and silent-renew
+   * handlers should check this flag to avoid kicking off a new auth flow
+   * during that window.
+   */
+  get isLoggingOut(): boolean {
+    return this._oidc.isLoggingOut === true;
+  }
+
   silentLoginCallbackAsync(): Promise<void> {
     return this._oidc.silentLoginCallbackAsync();
   }

--- a/packages/react-oidc/src/OidcSecure.tsx
+++ b/packages/react-oidc/src/OidcSecure.tsx
@@ -16,7 +16,11 @@ export const OidcSecure: FC<PropsWithChildren<OidcSecureProps>> = ({
   const getOidc = OidcClient.get;
   const oidc = getOidc(configurationName);
   useEffect(() => {
-    if (!oidc.tokens) {
+    // Skip auto re-login while a logout flow is in progress: in that window
+    // `tokens` has just been cleared but the browser has not yet navigated to
+    // the identity provider's end-session endpoint, and starting a new auth
+    // flow here would race the logout navigation (see issue #1677).
+    if (!oidc.tokens && !oidc.isLoggingOut) {
       oidc.loginAsync(callbackPath, extras);
     }
   }, [configurationName, callbackPath, extras]);


### PR DESCRIPTION
This PR updates the logoutAsync flow so that the local session is not cleared before navigation to the logout endpoint, preventing a race condition with OidcProvider that could trigger unintended re-authentication. The change ensures session cleanup happens in a safer order relative to navigation events. Additional guards and/or timing adjustments are introduced to make the logout process more deterministic. Tests and behavior are aligned with the expected logout experience to avoid regressions.

Closes #1677.

Additional context from Copilot / analysis:
Thanks for the very detailed report — this is a real bug and your analysis matches what the code does today.

**Confirming the race**

In `packages/oidc-client/src/logout.ts`, `logoutAsync` currently performs the following sequence (simplified):

1. Revoke `access_token` / `refresh_token` against the `revocation_endpoint` (awaited).
2. `await oidc.destroyAsync(&#39;LOGGED_OUT&#39;)` — this clears the session storage / service worker tokens, sets `oidc.tokens = null` / `oidc.userInfo = null`, and via the loop right after publishes `logout_from_same_tab`.
3. Build the `end_session_endpoint` URL (with `id_token_hint` and `post_logout_redirect_uri`).
4. `oicLocation.open(endSessionEndpoint + queryString)` to actually navigate the browser to the IdP logout.

Between step 2 and step 4 the page is still alive but the OIDC state is already wiped. Anything that observes that state — `OidcProvider` re-rendering, a `tokenRenew` / silent-renew timer that fires, an event listener triggering a guard that calls `loginAsync`, a 401 retry interceptor, etc. — can kick off a new auth flow before the navigation to `end_session_endpoint` happens. On slow networks / mobile / heavy React trees this window is easily long enough to lose the race, exactly as you described, which is why your workaround (build the end-session URL yourself, navigate, then clear the SW tokens after navigation has committed) works.

There are also two related side effects of clearing first:

- `id_token_hint` is read from `oidc.tokens.idToken` *before* `destroyAsync`, so it still works today — but only by accident of ordering. Any future refactor that moves the read after the clear would silently break `id_token_hint`.
- `logout_from_same_tab` is broadcast before navigation, so other tabs/providers may try to react to a logout that has not actually happened at the IdP yet.

**Proposed fix**

We should reorder `logoutAsync` so the browser navigation to `end_session_endpoint` happens *before* local state is cleared, and expose a small dedicated API for callers who want to clear local session explicitly. Concretely:

1. **Reorder in `logout.ts`:**
   - Keep token revocation calls where they are (they must happen while we still have the tokens, and they’re server-to-server-ish so they don’t trigger the React race).
   - Capture `idToken` and `sub` into local variables (already done for `idToken`, do the same for `sub`).
   - Build the `end_session_endpoint` URL.
   - Call `oicLocation.open(...)` (or `oicLocation.reload()` in the no-endpoint branch) **first**.
   - Then call `await oidc.destroyAsync(&#39;LOGGED_OUT&#39;)` and the `logoutSameTabAsync` loop. In practice the page is being unloaded so this mostly just keeps the in-memory state consistent if the navigation is cancelled (e.g. `beforeunload`), and avoids the listener-storm race. The `no_reload === &#39;true&#39;` branch should keep its current behavior (clear, then return, no navigation).

2. **Add an explicit `clearSessionAsync` / `clearLocalSessionAsync` API** on the `Oidc` client (and re-export it from `oidcClient.ts` and `react-oidc`) that wraps `destroyAsync(&#39;LOGGED_OUT&#39;)` + the `logout_from_same_tab` event, without touching `end_session_endpoint` or revocation. This gives integrators (your service-worker workaround, SPA-only logouts, error-recovery flows) a supported way to do exactly what you’re doing manually today.

3. **Guard `OidcProvider` against the transient &quot;no tokens&quot; state during logout** as a defense in depth: set an internal `isLoggingOut` flag at the start of `logoutAsync` and clear it only on unload / error, and make the provider skip auto-login / silent-renew while that flag is set. This makes the fix robust even if a consumer triggers `clearSessionAsync` manually.

4. **Tests** (`packages/oidc-client/src/logout.spec.ts`): add a test asserting the call order — `oicLocation.open` is invoked before `destroyAsync` resolves, and `id_token_hint` is still present on the resulting URL. Add a test for the new `clearSessionAsync` API. Add a test for the `no_reload` extras path to make sure it still clears and does not navigate.

**Compatibility**

The reorder is backwards-compatible for the documented behavior of `logoutAsync` (still ends up at `end_session_endpoint`, still revokes tokens, still clears local state). The only observable change is that `logout_from_same_tab` and the cleared `tokens`/`userInfo` state happen marginally later, which is the entire point of the fix. The new `clearSessionAsync` is purely additive.

**Security note**

Because this touches the logout / session-termination path it has security implications — we need to make sure that:

- Token revocation is still awaited before navigation, so a cancelled navigation doesn’t leave valid tokens in storage and on the AS.
- Cross-tab logout (`logoutSameTabAsync`) still fires for the *other* configurations, even if it’s now interleaved with navigation in the current tab.
- `id_token_hint` keeps being sent so the IdP can actually identify the session being ended.

If you’d like, I can put up a PR implementing 1 + 2 + the tests, and a follow-up PR for 3 in `react-oidc`. Could you also confirm the exact `oidc-client`/`react-oidc` version you’re on and your `storage` setting (`localStorage` / `sessionStorage` / service worker), so we can add a regression test that matches your scenario?
