### PR TITLE
Fix for issue #1675: Handle service worker AbortError on tab shutdown

### DIFF
--- a/packages/oidc-client/src/initWorker.ts
+++ b/packages/oidc-client/src/initWorker.ts
@@ -172,7 +172,18 @@ let controllerChangeReloading = false;
 // Cache registration promises by URL so that navigator.serviceWorker.register (or a custom
 // service_worker_register) is called at most once per JavaScript session (page lifetime),
 // regardless of how many times initWorkerAsync is invoked.
-const registrationCache = new Map<string, Promise<ServiceWorkerRegistration>>();
+export const registrationCache = new Map<string, Promise<ServiceWorkerRegistration>>();
+
+// AbortError surfaces during transient lifecycle events (e.g. iOS Safari tab shutdown or
+// backgrounding) and does not represent a genuine configuration problem. We treat it as
+// non-fatal, clear the cache entry so future calls can retry, and fall back to the
+// non–service-worker path by returning null from initWorkerAsync.
+const isAbortError = (error: unknown): boolean => {
+  if (error instanceof DOMException) {
+    return error.name === 'AbortError';
+  }
+  return (error as { name?: string } | null)?.name === 'AbortError';
+};
 
 // Session-level guard to prevent infinite reload loops caused by SW update cycles.
 // The controllerchange listener triggers a page reload, but after reload the module-level
@@ -229,25 +240,34 @@ export const initWorkerAsync = async (
 
   const swUrl = `${serviceWorkerRelativeUrl}?v=${codeVersion}`;
 
+  const cacheKey = configuration.service_worker_register ? serviceWorkerRelativeUrl : swUrl;
+
+  if (!registrationCache.has(cacheKey)) {
+    registrationCache.set(
+      cacheKey,
+      configuration.service_worker_register
+        ? configuration.service_worker_register(serviceWorkerRelativeUrl)
+        : navigator.serviceWorker.register(swUrl, {
+            updateViaCache: 'none',
+          }),
+    );
+  }
+
   let registration: ServiceWorkerRegistration = null as any;
-  if (configuration.service_worker_register) {
-    if (!registrationCache.has(serviceWorkerRelativeUrl)) {
-      registrationCache.set(
-        serviceWorkerRelativeUrl,
-        configuration.service_worker_register(serviceWorkerRelativeUrl),
+  try {
+    registration = await registrationCache.get(cacheKey)!;
+  } catch (error) {
+    if (isAbortError(error)) {
+      // Drop the rejected promise so a later call can attempt registration again
+      // once the browser is in a stable state (e.g. tab is foregrounded again).
+      registrationCache.delete(cacheKey);
+      console.warn(
+        'oidc-client: service worker registration was aborted (likely tab shutdown or backgrounding); falling back to non–service-worker mode.',
+        error,
       );
+      return null;
     }
-    registration = await registrationCache.get(serviceWorkerRelativeUrl)!;
-  } else {
-    if (!registrationCache.has(swUrl)) {
-      registrationCache.set(
-        swUrl,
-        navigator.serviceWorker.register(swUrl, {
-          updateViaCache: 'none',
-        }),
-      );
-    }
-    registration = await registrationCache.get(swUrl)!;
+    throw error;
   }
 
   const versionMismatchKey = `oidc.sw.version_mismatch_reload.${configurationName}`;

--- a/packages/oidc-client/src/initWorkerAbortError.spec.ts
+++ b/packages/oidc-client/src/initWorkerAbortError.spec.ts
@@ -1,0 +1,147 @@
+// Tests covering the AbortError handling added to initWorkerAsync.
+// See https://github.com/AxaFrance/oidc-client/issues/1675
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initWorkerAsync, registrationCache } from './initWorker';
+import { OidcConfiguration } from './types';
+
+const SERVICE_WORKER_RELATIVE_URL = '/OidcServiceWorker.js';
+
+const buildConfiguration = (overrides: Partial<OidcConfiguration> = {}): OidcConfiguration => {
+  return {
+    client_id: 'test-client',
+    redirect_uri: 'http://localhost/callback',
+    scope: 'openid',
+    authority: 'http://authority',
+    service_worker_relative_url: SERVICE_WORKER_RELATIVE_URL,
+    service_worker_activate: () => true,
+    ...overrides,
+  } as OidcConfiguration;
+};
+
+const createAbortError = (): DOMException => {
+  // DOMException is available in the test environment (jsdom / happy-dom).
+  return new DOMException('The operation was aborted.', 'AbortError');
+};
+
+describe('initWorkerAsync AbortError handling', () => {
+  let originalNavigator: PropertyDescriptor | undefined;
+  let originalWindow: PropertyDescriptor | undefined;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    registrationCache.clear();
+    originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+    originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {},
+    });
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        serviceWorker: {
+          register: vi.fn(),
+          ready: Promise.resolve({} as ServiceWorkerRegistration),
+          controller: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        },
+      },
+    });
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    registrationCache.clear();
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, 'navigator', originalNavigator);
+    } else {
+      delete (globalThis as { navigator?: unknown }).navigator;
+    }
+    if (originalWindow) {
+      Object.defineProperty(globalThis, 'window', originalWindow);
+    } else {
+      delete (globalThis as { window?: unknown }).window;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when a custom service_worker_register rejects with an AbortError', async () => {
+    const abortError = createAbortError();
+    const service_worker_register = vi.fn(() => Promise.reject(abortError));
+
+    const result = await initWorkerAsync(
+      buildConfiguration({ service_worker_register }),
+      'default',
+    );
+
+    expect(result).toBeNull();
+    expect(service_worker_register).toHaveBeenCalledOnce();
+    expect(registrationCache.has(SERVICE_WORKER_RELATIVE_URL)).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('returns null when navigator.serviceWorker.register rejects with an AbortError', async () => {
+    const abortError = createAbortError();
+    (navigator.serviceWorker.register as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => Promise.reject(abortError),
+    );
+
+    const result = await initWorkerAsync(buildConfiguration(), 'default');
+
+    expect(result).toBeNull();
+    // The cache entry for the SW URL should have been cleared so a later retry is possible.
+    expect(Array.from(registrationCache.keys())).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('also treats plain { name: "AbortError" } rejections as aborts', async () => {
+    const plainAbort = { name: 'AbortError', message: 'aborted' };
+    const service_worker_register = vi.fn(() => Promise.reject(plainAbort));
+
+    const result = await initWorkerAsync(
+      buildConfiguration({ service_worker_register }),
+      'default',
+    );
+
+    expect(result).toBeNull();
+    expect(registrationCache.has(SERVICE_WORKER_RELATIVE_URL)).toBe(false);
+  });
+
+  it('allows a subsequent call to retry registration after an AbortError', async () => {
+    const abortError = createAbortError();
+    const service_worker_register = vi
+      .fn()
+      .mockImplementationOnce(() => Promise.reject(abortError))
+      // Returning a never-resolving promise on the retry is fine for the assertion below:
+      // we only need to confirm that the function was called a second time after the
+      // failed cache entry was cleared.
+      .mockImplementationOnce(() => new Promise<ServiceWorkerRegistration>(() => {}));
+
+    const configuration = buildConfiguration({ service_worker_register });
+
+    const firstResult = await initWorkerAsync(configuration, 'default');
+    expect(firstResult).toBeNull();
+    expect(service_worker_register).toHaveBeenCalledTimes(1);
+
+    // Kick off the second call (don't await – the mocked promise never resolves).
+    void initWorkerAsync(configuration, 'default');
+    // Allow the microtask queue to drain so the registration call is observed.
+    await Promise.resolve();
+
+    expect(service_worker_register).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates non-AbortError rejections to the caller', async () => {
+    const genericError = new Error('boom');
+    const service_worker_register = vi.fn(() => Promise.reject(genericError));
+
+    await expect(
+      initWorkerAsync(buildConfiguration({ service_worker_register }), 'default'),
+    ).rejects.toBe(genericError);
+
+    // Non-AbortError rejections keep the cache entry in place (existing behavior).
+    expect(registrationCache.has(SERVICE_WORKER_RELATIVE_URL)).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR updates the service worker registration logic so that AbortError conditions triggered during tab shutdown are caught and handled gracefully. It ensures that these expected abort scenarios do not surface as uncaught promise rejections in the console. The change adds appropriate error handling and filtering while keeping genuine errors visible for debugging. This improves robustness and reduces noise when tabs are closed or navigated away from.

Closes #1675.

Additional context from Copilot / analysis:
Thanks for the detailed analysis and for proposing a concrete way to handle this behavior.

From the description, this is indeed an undesirable side effect of how `initWorkerAsync` caches the `navigator.serviceWorker.register` promise: when registration is aborted by the browser (common during tab shutdown/backgrounding on iOS Safari), the resulting rejected promise (with an `AbortError` DOMException) is stored in `registrationCache` and then re-thrown to every subsequent caller. Functionally the library already falls back correctly when service workers are not available, but this caching behavior results in noisy, misleading uncaught promise rejections for consumers and pollutes error monitoring.

Treating these shutdown-style `AbortError`s as internal and non-fatal makes sense and is compatible with the existing design of `initWorkerAsync`, which already returns `null` in other “no SW” scenarios.

### Recommended behavior change

Inside `initWorkerAsync` (in `packages/oidc-client/src/initWorker.ts`):

1. Wrap the awaited registration promise in a `try/catch` instead of letting the rejection propagate unchecked.
2. Detect an `AbortError` (from either the built-in `navigator.serviceWorker.register` or a custom `service_worker_register`).
3. For `AbortError`:
   - Remove the failed entry from `registrationCache` so future calls can retry.
   - Log a warning (e.g., `console.warn`) explaining that registration was aborted, likely due to tab shutdown/backgrounding.
   - Return `null` to trigger the existing non–service worker fallback path.
4. For any non-`AbortError` errors, rethrow them so real configuration or runtime issues remain visible to consumers.

Conceptually, the code would follow this pattern (simplified for illustration):

```ts
const cacheKey = configuration.service_worker_register ? serviceWorkerRelativeUrl : swUrl;

if (!registrationCache.has(cacheKey)) {
  registrationCache.set(
    cacheKey,
    configuration.service_worker_register
      ? configuration.service_worker_register(serviceWorkerRelativeUrl)
      : navigator.serviceWorker.register(swUrl, { updateViaCache: &#39;none&#39; }),
  );
}

let registration: ServiceWorkerRegistration | null;

try {
  registration = await registrationCache.get(cacheKey)!;
} catch (error) {
  const isAbortError =
    error instanceof DOMException ? error.name === &#39;AbortError&#39;
    : (error as { name?: string } | null)?.name === &#39;AbortError&#39;;

  if (isAbortError) {
    registrationCache.delete(cacheKey);
    console.warn(
      &#39;oidc-client: service worker registration was aborted (likely tab shutdown); falling back to non–service-worker mode.&#39;,
      error,
    );
    return null;
  }

  // Preserve previous behavior for non-Abort errors
  throw error;
}

// Existing logic continues as before, using `registration`
```

### Rationale

- Returning `null` is consistent with other branches in `initWorkerAsync` that indicate “no usable service worker” (e.g., `navigator.serviceWorker` missing, or `service_worker_activate()` explicitly disabling SW usage). The rest of the code is already prepared to use the non–service worker fallback in that case.
- Clearing the cache on `AbortError` prevents the same rejected promise from being reused after a transient shutdown abort, which would otherwise continue to generate spurious errors.
- Restricting this behavior to `AbortError` keeps genuine registration problems (e.g., scope, MIME type, security errors) visible to app developers and their monitoring systems.

### Testing suggestions

It would be good to add tests that:

1. Simulate `service_worker_register` throwing or returning a rejected promise with `name === &#39;AbortError&#39;` and assert that:
   - `initWorkerAsync` resolves with `null`.
   - The corresponding `registrationCache` entry is cleared.
2. Simulate `navigator.serviceWorker.register` rejecting with an `AbortError` and assert the same behavior.
3. Simulate a non-`AbortError` rejection and assert that the error is propagated (no swallowing, cache behavior remains as before or is explicitly defined).

### Next steps

The change itself should be relatively small and localized to `initWorkerAsync`. If you are interested in contributing a PR, a patch along the lines of the above (plus tests) would be very welcome. Otherwise, this issue can track implementing that behavior in a future release so that `AbortError` from tab shutdown/backgrounding no longer appears as an uncaught rejection for consumers while preserving the existing, correct fallback logic.
