### PR TITLE
[evolution] Untyped errors force consumers to string-match Error.message for control flow (#1676)

### DIFF
--- a/packages/oidc-client/src/index.ts
+++ b/packages/oidc-client/src/index.ts
@@ -5,6 +5,20 @@ export { OidcLocation } from './location.js';
 export { getFetchDefault } from './oidc.js';
 export type { OidcUserInfo } from './oidcClient.js';
 export { OidcClient } from './oidcClient.js';
+export {
+  isOidcError,
+  isOidcLoginRequiredError,
+  isOidcServerError,
+  isOidcSilentLoginTimeoutError,
+  isOidcTokenRequestFailedError,
+  OidcError,
+  OidcErrorCode,
+  OidcLoginRequiredError,
+  OidcServerError,
+  OidcSilentLoginTimeoutError,
+  OidcTokenRequestFailedError,
+  TokenRequestFailedPhase,
+} from './oidcError.js';
 export { isOidcStateError, OidcStateError, OidcStateErrorCode } from './oidcStateError.js';
 export type { Tokens } from './parseTokens.js';
 export { TokenRenewMode } from './parseTokens.js';

--- a/packages/oidc-client/src/login.spec.ts
+++ b/packages/oidc-client/src/login.spec.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ILOidcLocation } from './location';
 import { loginCallbackAsync } from './login';
+import { OidcErrorCode, OidcLoginRequiredError, OidcServerError } from './oidcError';
 import { OidcStateError, OidcStateErrorCode } from './oidcStateError';
 
 const makeStorage = (): Storage => {
@@ -147,5 +148,66 @@ describe('loginCallbackAsync — state/nonce guards (issue #1678)', () => {
     }
     expect(caught).toBeInstanceOf(OidcStateError);
     expect(caught).not.toBeInstanceOf(TypeError);
+  });
+});
+
+describe('loginCallbackAsync — typed IdP error responses (issue #1676)', () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = makeStorage();
+  });
+
+  it('throws OidcLoginRequiredError when the IdP returns error=login_required', async () => {
+    const href =
+      'http://localhost:4200/authentication/callback?error=login_required&error_description=User%20must%20re-authenticate';
+    const { oidc, publishedEvents } = buildOidc({ href, storage });
+
+    let caught: unknown;
+    try {
+      await loginCallbackAsync(oidc)();
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(OidcLoginRequiredError);
+    // The login_required error is also an OidcServerError so consumers can
+    // either match the specific subclass or branch on the parent type.
+    expect(caught).toBeInstanceOf(OidcServerError);
+    expect((caught as OidcLoginRequiredError).code).toBe(OidcErrorCode.LOGIN_REQUIRED);
+    expect((caught as OidcLoginRequiredError).serverError).toBe('login_required');
+    expect((caught as OidcLoginRequiredError).serverErrorDescription).toBe(
+      'User must re-authenticate',
+    );
+    // Message text is preserved for legacy string-matching consumers.
+    expect((caught as Error).message).toBe(
+      'Error from OIDC server: login_required - User must re-authenticate',
+    );
+
+    const errorEvent = publishedEvents.find(e => e.name === 'loginCallbackAsync_error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent!.data).toBeInstanceOf(OidcLoginRequiredError);
+  });
+
+  it('throws OidcServerError for non-login_required IdP errors', async () => {
+    const href =
+      'http://localhost:4200/authentication/callback?error=invalid_request&error_description=redirect_uri%20mismatch';
+    const { oidc } = buildOidc({ href, storage });
+
+    let caught: unknown;
+    try {
+      await loginCallbackAsync(oidc)();
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(OidcServerError);
+    expect(caught).not.toBeInstanceOf(OidcLoginRequiredError);
+    expect((caught as OidcServerError).code).toBe(OidcErrorCode.OIDC_SERVER_ERROR);
+    expect((caught as OidcServerError).serverError).toBe('invalid_request');
+    expect((caught as OidcServerError).serverErrorDescription).toBe('redirect_uri mismatch');
+    expect((caught as Error).message).toBe(
+      'Error from OIDC server: invalid_request - redirect_uri mismatch',
+    );
   });
 });

--- a/packages/oidc-client/src/login.ts
+++ b/packages/oidc-client/src/login.ts
@@ -5,6 +5,12 @@ import { initWorkerAsync } from './initWorker.js';
 import { generateJwkAsync, generateJwtDemonstratingProofOfPossessionAsync } from './jwt';
 import { ILOidcLocation } from './location';
 import Oidc from './oidc';
+import {
+  OidcLoginRequiredError,
+  OidcServerError,
+  OidcTokenRequestFailedError,
+  TokenRequestFailedPhase,
+} from './oidcError.js';
 import { OidcStateError, OidcStateErrorCode } from './oidcStateError.js';
 import { isTokensOidcValid } from './parseTokens.js';
 import { performAuthorizationRequestAsync, performFirstTokenRequestAsync } from './requests.js';
@@ -146,9 +152,17 @@ export const loginCallbackAsync =
       }
 
       if (queryParams.error || queryParams.error_description) {
-        throw new Error(
-          `Error from OIDC server: ${queryParams.error} - ${queryParams.error_description}`,
-        );
+        // Surface IdP errors as a typed `OidcServerError` (or its
+        // `OidcLoginRequiredError` specialization for the very common
+        // `login_required` case) so consumers can branch on `instanceof`
+        // / `error.code` instead of pattern-matching the message text.
+        // The original message format is preserved for backwards
+        // compatibility. See https://github.com/AxaFrance/oidc-client/issues/1676
+        const message = `Error from OIDC server: ${queryParams.error} - ${queryParams.error_description}`;
+        if (queryParams.error === 'login_required') {
+          throw new OidcLoginRequiredError(queryParams.error_description, message);
+        }
+        throw new OidcServerError(queryParams.error, queryParams.error_description, message);
       }
 
       if (queryParams.iss && queryParams.iss !== oidcServerConfiguration.issuer) {
@@ -233,7 +247,10 @@ export const loginCallbackAsync =
       );
 
       if (!tokenResponse.success) {
-        throw new Error('Token request failed');
+        // Typed so consumers can distinguish a login-callback failure from
+        // refresh / cross-tab-sync failures (which share the same message
+        // text). See https://github.com/AxaFrance/oidc-client/issues/1676
+        throw new OidcTokenRequestFailedError(TokenRequestFailedPhase.LOGIN_CALLBACK);
       }
 
       let loginParams;

--- a/packages/oidc-client/src/oidcError.spec.ts
+++ b/packages/oidc-client/src/oidcError.spec.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isOidcError,
+  isOidcLoginRequiredError,
+  isOidcServerError,
+  isOidcSilentLoginTimeoutError,
+  isOidcTokenRequestFailedError,
+  OidcError,
+  OidcErrorCode,
+  OidcLoginRequiredError,
+  OidcServerError,
+  OidcSilentLoginTimeoutError,
+  OidcTokenRequestFailedError,
+  TokenRequestFailedPhase,
+} from './oidcError';
+
+describe('OidcErrorCode', () => {
+  it('exposes the well-known error codes as stable string values', () => {
+    expect(OidcErrorCode.SILENT_LOGIN_TIMEOUT).toBe('SILENT_LOGIN_TIMEOUT');
+    expect(OidcErrorCode.OIDC_SERVER_ERROR).toBe('OIDC_SERVER_ERROR');
+    expect(OidcErrorCode.LOGIN_REQUIRED).toBe('LOGIN_REQUIRED');
+    expect(OidcErrorCode.TOKEN_REQUEST_FAILED).toBe('TOKEN_REQUEST_FAILED');
+  });
+});
+
+describe('TokenRequestFailedPhase', () => {
+  it('exposes the three well-known upstream phases', () => {
+    expect(TokenRequestFailedPhase.LOGIN_CALLBACK).toBe('login_callback');
+    expect(TokenRequestFailedPhase.REFRESH).toBe('refresh');
+    expect(TokenRequestFailedPhase.SYNC).toBe('sync');
+  });
+});
+
+describe('OidcError', () => {
+  it('is an Error subclass that carries a code and an optional phase', () => {
+    const err = new OidcError('boom', 'CUSTOM_CODE', 'custom_phase');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(OidcError);
+    expect(err.message).toBe('boom');
+    expect(err.code).toBe('CUSTOM_CODE');
+    expect(err.phase).toBe('custom_phase');
+    expect(err.name).toBe('OidcError');
+  });
+
+  it('leaves phase undefined when not provided', () => {
+    const err = new OidcError('boom', 'CUSTOM_CODE');
+    expect(err.phase).toBeUndefined();
+  });
+
+  it('is detectable via isOidcError', () => {
+    expect(isOidcError(new OidcError('boom', 'X'))).toBe(true);
+    expect(isOidcError(new Error('boom'))).toBe(false);
+    expect(isOidcError(null)).toBe(false);
+    expect(isOidcError({ code: 'X' })).toBe(false);
+  });
+});
+
+describe('OidcSilentLoginTimeoutError', () => {
+  it('preserves the legacy "timeout" message for backwards compatibility', () => {
+    const err = new OidcSilentLoginTimeoutError();
+    expect(err.message).toBe('timeout');
+  });
+
+  it('exposes the SILENT_LOGIN_TIMEOUT code and proper subclass identity', () => {
+    const err = new OidcSilentLoginTimeoutError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(OidcError);
+    expect(err).toBeInstanceOf(OidcSilentLoginTimeoutError);
+    expect(err.code).toBe(OidcErrorCode.SILENT_LOGIN_TIMEOUT);
+    expect(err.name).toBe('OidcSilentLoginTimeoutError');
+  });
+
+  it('is detectable via isOidcSilentLoginTimeoutError', () => {
+    expect(isOidcSilentLoginTimeoutError(new OidcSilentLoginTimeoutError())).toBe(true);
+    expect(isOidcSilentLoginTimeoutError(new Error('timeout'))).toBe(false);
+    expect(isOidcSilentLoginTimeoutError(new OidcError('timeout', 'OTHER'))).toBe(false);
+  });
+});
+
+describe('OidcServerError', () => {
+  it('exposes the raw server error and description on the typed fields', () => {
+    const err = new OidcServerError('invalid_request', 'redirect_uri mismatch');
+    expect(err).toBeInstanceOf(OidcError);
+    expect(err).toBeInstanceOf(OidcServerError);
+    expect(err.code).toBe(OidcErrorCode.OIDC_SERVER_ERROR);
+    expect(err.serverError).toBe('invalid_request');
+    expect(err.serverErrorDescription).toBe('redirect_uri mismatch');
+  });
+
+  it('builds a default message that preserves the historical format', () => {
+    const err = new OidcServerError('invalid_request', 'redirect_uri mismatch');
+    expect(err.message).toBe('Error from OIDC server: invalid_request - redirect_uri mismatch');
+  });
+
+  it('accepts a custom message override', () => {
+    const err = new OidcServerError('invalid_request', 'desc', 'custom message');
+    expect(err.message).toBe('custom message');
+  });
+
+  it('is detectable via isOidcServerError, including subclasses', () => {
+    expect(isOidcServerError(new OidcServerError('a', 'b'))).toBe(true);
+    expect(isOidcServerError(new OidcLoginRequiredError())).toBe(true);
+    expect(isOidcServerError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('OidcLoginRequiredError', () => {
+  it('is a specialization of OidcServerError with code LOGIN_REQUIRED', () => {
+    const err = new OidcLoginRequiredError('user not signed in');
+    expect(err).toBeInstanceOf(OidcServerError);
+    expect(err).toBeInstanceOf(OidcLoginRequiredError);
+    expect(err.code).toBe(OidcErrorCode.LOGIN_REQUIRED);
+    expect(err.serverError).toBe('login_required');
+    expect(err.serverErrorDescription).toBe('user not signed in');
+    expect(err.name).toBe('OidcLoginRequiredError');
+  });
+
+  it('is detectable via isOidcLoginRequiredError but not via timeout/token guards', () => {
+    const err = new OidcLoginRequiredError();
+    expect(isOidcLoginRequiredError(err)).toBe(true);
+    expect(isOidcServerError(err)).toBe(true);
+    expect(isOidcError(err)).toBe(true);
+    expect(isOidcSilentLoginTimeoutError(err)).toBe(false);
+    expect(isOidcTokenRequestFailedError(err)).toBe(false);
+  });
+});
+
+describe('OidcTokenRequestFailedError', () => {
+  it('preserves the legacy "Token request failed" message by default', () => {
+    const err = new OidcTokenRequestFailedError(TokenRequestFailedPhase.LOGIN_CALLBACK);
+    expect(err.message).toBe('Token request failed');
+  });
+
+  it('carries the phase discriminator so callers can disambiguate call sites', () => {
+    const loginCallback = new OidcTokenRequestFailedError(TokenRequestFailedPhase.LOGIN_CALLBACK);
+    const refresh = new OidcTokenRequestFailedError(TokenRequestFailedPhase.REFRESH);
+    const sync = new OidcTokenRequestFailedError(TokenRequestFailedPhase.SYNC);
+
+    expect(loginCallback.phase).toBe('login_callback');
+    expect(refresh.phase).toBe('refresh');
+    expect(sync.phase).toBe('sync');
+  });
+
+  it('exposes the TOKEN_REQUEST_FAILED code and proper subclass identity', () => {
+    const err = new OidcTokenRequestFailedError(TokenRequestFailedPhase.LOGIN_CALLBACK);
+    expect(err).toBeInstanceOf(OidcError);
+    expect(err).toBeInstanceOf(OidcTokenRequestFailedError);
+    expect(err.code).toBe(OidcErrorCode.TOKEN_REQUEST_FAILED);
+    expect(err.name).toBe('OidcTokenRequestFailedError');
+  });
+
+  it('accepts a custom message override', () => {
+    const err = new OidcTokenRequestFailedError(
+      TokenRequestFailedPhase.REFRESH,
+      'custom token failure',
+    );
+    expect(err.message).toBe('custom token failure');
+  });
+
+  it('is detectable via isOidcTokenRequestFailedError', () => {
+    const err = new OidcTokenRequestFailedError(TokenRequestFailedPhase.SYNC);
+    expect(isOidcTokenRequestFailedError(err)).toBe(true);
+    expect(isOidcTokenRequestFailedError(new Error('Token request failed'))).toBe(false);
+  });
+});

--- a/packages/oidc-client/src/oidcError.ts
+++ b/packages/oidc-client/src/oidcError.ts
@@ -1,0 +1,209 @@
+/**
+ * Typed error layer for the oidc-client library.
+ *
+ * Historically the library threw bare `new Error('...')` instances in several
+ * control-flow-relevant places, forcing consumers to match against
+ * `error.message` substrings to decide whether to retry, redirect or surface
+ * an error to the user. That is brittle to message-text changes between
+ * releases and conflates unrelated failure modes (e.g. the same
+ * `"Token request failed"` message can surface from three different
+ * code paths).
+ *
+ * This module introduces an additive typed-error hierarchy: errors expose a
+ * stable, machine-readable {@link OidcError.code} (and, where relevant, a
+ * {@link OidcError.phase} discriminator) while preserving the original
+ * `message` text — so existing string-matching keeps working and consumers
+ * who care can migrate to `error instanceof OidcSilentLoginTimeoutError` or
+ * `error.code === OidcErrorCode.SILENT_LOGIN_TIMEOUT`.
+ *
+ * See https://github.com/AxaFrance/oidc-client/issues/1676
+ */
+
+/**
+ * Stable, machine-readable codes for typed OIDC errors. The string values
+ * are part of the library's public contract and will not change between
+ * minor releases.
+ */
+export const OidcErrorCode = {
+  /** A silent (iframe-based) renewal exceeded `silent_login_timeout`. */
+  SILENT_LOGIN_TIMEOUT: 'SILENT_LOGIN_TIMEOUT',
+  /**
+   * The authorization server returned an error response. The original
+   * `error` / `error_description` query parameters are preserved on
+   * {@link OidcServerError.serverError} and
+   * {@link OidcServerError.serverErrorDescription}.
+   */
+  OIDC_SERVER_ERROR: 'OIDC_SERVER_ERROR',
+  /**
+   * The authorization server explicitly answered `login_required` (the user
+   * needs to re-authenticate interactively). This is a specialization of
+   * {@link OidcErrorCode.OIDC_SERVER_ERROR}.
+   */
+  LOGIN_REQUIRED: 'LOGIN_REQUIRED',
+  /**
+   * The token endpoint did not return a successful response. The
+   * {@link OidcTokenRequestFailedError.phase} field distinguishes the
+   * upstream call site (login callback, refresh, or cross-tab sync).
+   */
+  TOKEN_REQUEST_FAILED: 'TOKEN_REQUEST_FAILED',
+} as const;
+
+// Companion type that mirrors the const above. We intentionally reuse the
+// same name so that `OidcErrorCode` works as both a value namespace and a
+// type for consumers.
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type OidcErrorCode = (typeof OidcErrorCode)[keyof typeof OidcErrorCode];
+
+/**
+ * Identifies the upstream code path that produced an
+ * {@link OidcTokenRequestFailedError}. Consumers who want to react
+ * differently to a fresh login failure, a silent refresh failure or a
+ * cross-tab sync failure should switch on this value rather than the
+ * dispatched event name.
+ */
+export const TokenRequestFailedPhase = {
+  /** Token request issued from the authorization-code callback. */
+  LOGIN_CALLBACK: 'login_callback',
+  /** Token request issued from a refresh-token renewal. */
+  REFRESH: 'refresh',
+  /** Token request issued from a cross-tab token synchronisation. */
+  SYNC: 'sync',
+} as const;
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type TokenRequestFailedPhase =
+  (typeof TokenRequestFailedPhase)[keyof typeof TokenRequestFailedPhase];
+
+/**
+ * Base class for all typed errors thrown by oidc-client.
+ *
+ * Carries a stable {@link code} discriminator and an optional {@link phase}
+ * to distinguish call sites that share the same code. Subclasses set a
+ * specific `name` so that errors are easy to identify in logs and across
+ * realms.
+ *
+ * Existing consumers that match `error.message` keep working: subclasses
+ * preserve the original message text.
+ */
+export class OidcError extends Error {
+  readonly code: string;
+  readonly phase?: string;
+
+  constructor(message: string, code: string, phase?: string) {
+    super(message);
+    this.name = 'OidcError';
+    this.code = code;
+    this.phase = phase;
+
+    // Keep prototype chain intact when transpiled to ES5.
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Thrown when a silent (iframe-based) login or token renewal exceeds the
+ * configured `silent_login_timeout`.
+ *
+ * The message is kept as `"timeout"` for backwards compatibility with
+ * consumers doing `error.message === 'timeout'`.
+ */
+export class OidcSilentLoginTimeoutError extends OidcError {
+  constructor(message = 'timeout') {
+    super(message, OidcErrorCode.SILENT_LOGIN_TIMEOUT);
+    this.name = 'OidcSilentLoginTimeoutError';
+    Object.setPrototypeOf(this, OidcSilentLoginTimeoutError.prototype);
+  }
+}
+
+/**
+ * Thrown when the authorization server responds with an `error` /
+ * `error_description` query parameter on the callback URL (e.g.
+ * `interaction_required`, `consent_required`, `invalid_request`, ...).
+ *
+ * The raw values are exposed verbatim on {@link serverError} and
+ * {@link serverErrorDescription} so that callers can react to specific
+ * server-side codes without parsing the message string.
+ */
+export class OidcServerError extends OidcError {
+  readonly serverError?: string;
+  readonly serverErrorDescription?: string;
+
+  constructor(
+    serverError: string | undefined,
+    serverErrorDescription: string | undefined,
+    message?: string,
+    code: string = OidcErrorCode.OIDC_SERVER_ERROR,
+  ) {
+    super(message ?? `Error from OIDC server: ${serverError} - ${serverErrorDescription}`, code);
+    this.name = 'OidcServerError';
+    this.serverError = serverError;
+    this.serverErrorDescription = serverErrorDescription;
+    Object.setPrototypeOf(this, OidcServerError.prototype);
+  }
+}
+
+/**
+ * Specialization of {@link OidcServerError} for the very common
+ * `login_required` response: the user must re-authenticate interactively.
+ *
+ * Consumers can branch on `error instanceof OidcLoginRequiredError`
+ * instead of doing `error.message.includes('login_required')`.
+ */
+export class OidcLoginRequiredError extends OidcServerError {
+  constructor(serverErrorDescription?: string, message?: string) {
+    super('login_required', serverErrorDescription, message, OidcErrorCode.LOGIN_REQUIRED);
+    this.name = 'OidcLoginRequiredError';
+    Object.setPrototypeOf(this, OidcLoginRequiredError.prototype);
+  }
+}
+
+/**
+ * Thrown when a token endpoint request did not return a successful
+ * response.
+ *
+ * The same message text (`"Token request failed"`) can originate from three
+ * different upstream paths; {@link phase} disambiguates them so that
+ * callers can implement path-specific recovery without inspecting the
+ * dispatched event name.
+ */
+export class OidcTokenRequestFailedError extends OidcError {
+  // Narrow the inherited `phase` field to the well-known union for
+  // consumers who pattern-match on it. The value itself is set by the
+  // base constructor.
+  declare readonly phase: TokenRequestFailedPhase;
+
+  constructor(phase: TokenRequestFailedPhase, message = 'Token request failed') {
+    super(message, OidcErrorCode.TOKEN_REQUEST_FAILED, phase);
+    this.name = 'OidcTokenRequestFailedError';
+    Object.setPrototypeOf(this, OidcTokenRequestFailedError.prototype);
+  }
+}
+
+/** Type guard for {@link OidcError} and any of its subclasses. */
+export const isOidcError = (value: unknown): value is OidcError => {
+  return value instanceof OidcError;
+};
+
+/** Type guard for {@link OidcSilentLoginTimeoutError}. */
+export const isOidcSilentLoginTimeoutError = (
+  value: unknown,
+): value is OidcSilentLoginTimeoutError => {
+  return value instanceof OidcSilentLoginTimeoutError;
+};
+
+/** Type guard for {@link OidcServerError} (and its subclasses). */
+export const isOidcServerError = (value: unknown): value is OidcServerError => {
+  return value instanceof OidcServerError;
+};
+
+/** Type guard for {@link OidcLoginRequiredError}. */
+export const isOidcLoginRequiredError = (value: unknown): value is OidcLoginRequiredError => {
+  return value instanceof OidcLoginRequiredError;
+};
+
+/** Type guard for {@link OidcTokenRequestFailedError}. */
+export const isOidcTokenRequestFailedError = (
+  value: unknown,
+): value is OidcTokenRequestFailedError => {
+  return value instanceof OidcTokenRequestFailedError;
+};

--- a/packages/oidc-client/src/silentLogin.ts
+++ b/packages/oidc-client/src/silentLogin.ts
@@ -1,4 +1,5 @@
 import { eventNames } from './events.js';
+import { OidcServerError, OidcSilentLoginTimeoutError } from './oidcError.js';
 import { Tokens } from './parseTokens.js';
 import { autoRenewTokens } from './renewTokens.js';
 import timer from './timer.js';
@@ -97,7 +98,12 @@ export const _silentLoginAsync =
                 } else if (data.startsWith(key_exception)) {
                   const result = JSON.parse(e.data.replace(key_exception, ''));
                   publishEvent(eventNames.silentLoginAsync_error, result);
-                  reject(new Error(result.error));
+                  // Preserve the original message text (the raw exception
+                  // string forwarded by the silent-login iframe) so that
+                  // existing consumers matching on `error.message` keep
+                  // working, while exposing a typed `OidcServerError` for
+                  // those who prefer `instanceof` / `error.code`.
+                  reject(new OidcServerError(result.error, undefined, result.error));
                   clear();
                 }
               }
@@ -113,7 +119,7 @@ export const _silentLoginAsync =
             if (!isResolved) {
               clear();
               publishEvent(eventNames.silentLoginAsync_error, { reason: 'timeout' });
-              reject(new Error('timeout'));
+              reject(new OidcSilentLoginTimeoutError());
             }
           }, silentSigninTimeout);
         } catch (e) {


### PR DESCRIPTION
evolution: Untyped errors force consumers to string-match Error.message for control flow (Issue #1676)

Summary of changes:
- Implements code changes to address the linked issue.
- Applies clean code practices and keeps changes focused.
- Updates or adds tests as appropriate for the new behavior.

References:
- Fixes #1676

Notes:
- Changes were implemented with the assistance of GitHub Copilot Agent.
